### PR TITLE
Add no-build Spotify album/playlist shuffler web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Spotify Album + Playlist Shuffler
+
+A no-build web app that:
+
+- Connects directly to Spotify with OAuth PKCE.
+- Lets you maintain a local list of album + playlist URIs in `localStorage`.
+- Randomizes the order of those selected items.
+- Plays each selected album/playlist in track order before advancing to the next.
+
+## Run locally
+
+Because OAuth redirect URIs must match exactly, serve this directory with any static server.
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open `http://localhost:4173`.
+
+## Spotify app setup
+
+1. In the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), create an app.
+2. Add your redirect URI (shown in the app UI) to the app settings.
+3. Copy the Client ID into the app.
+
+## Requested Spotify scopes (minimal)
+
+This app requests only:
+
+- `user-modify-playback-state` (start playback, turn shuffle off, turn repeat off)
+- `user-read-playback-state` (monitor active context and detect when to move to next item)
+
+No library-read scopes are required because the user provides album/playlist URIs manually.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,483 @@
+// @ts-check
+
+/** @typedef {'album' | 'playlist'} ItemType */
+
+/**
+ * @typedef ShuffleItem
+ * @property {string} uri
+ * @property {ItemType} type
+ */
+
+/**
+ * @typedef SessionState
+ * @property {boolean} active
+ * @property {ShuffleItem[]} queue
+ * @property {number} index
+ * @property {string | null} currentUri
+ * @property {boolean} observedCurrentContext
+ */
+
+const SCOPES = [
+  // control playback + read active playback context
+  'user-modify-playback-state',
+  'user-read-playback-state',
+];
+
+const STORAGE_KEYS = {
+  clientId: 'spotifyShuffler.clientId',
+  verifier: 'spotifyShuffler.pkceVerifier',
+  token: 'spotifyShuffler.token',
+  tokenExpiry: 'spotifyShuffler.tokenExpiry',
+  items: 'spotifyShuffler.items',
+};
+
+const el = {
+  clientId: /** @type {HTMLInputElement} */ (document.getElementById('client-id')),
+  loginBtn: /** @type {HTMLButtonElement} */ (document.getElementById('login-btn')),
+  logoutBtn: /** @type {HTMLButtonElement} */ (document.getElementById('logout-btn')),
+  authStatus: /** @type {HTMLParagraphElement} */ (document.getElementById('auth-status')),
+  redirectUri: /** @type {HTMLElement} */ (document.getElementById('redirect-uri')),
+  addForm: /** @type {HTMLFormElement} */ (document.getElementById('add-form')),
+  itemUri: /** @type {HTMLInputElement} */ (document.getElementById('item-uri')),
+  itemList: /** @type {HTMLUListElement} */ (document.getElementById('item-list')),
+  startBtn: /** @type {HTMLButtonElement} */ (document.getElementById('start-btn')),
+  skipBtn: /** @type {HTMLButtonElement} */ (document.getElementById('skip-btn')),
+  stopBtn: /** @type {HTMLButtonElement} */ (document.getElementById('stop-btn')),
+  playbackStatus: /** @type {HTMLParagraphElement} */ (document.getElementById('playback-status')),
+};
+
+/** @type {SessionState} */
+const session = {
+  active: false,
+  queue: [],
+  index: 0,
+  currentUri: null,
+  observedCurrentContext: false,
+};
+
+let monitorTimer = /** @type {number | null} */ (null);
+
+bootstrap().catch((error) => {
+  console.error(error);
+  setAuthStatus(`Startup error: ${error instanceof Error ? error.message : String(error)}`);
+});
+
+async function bootstrap() {
+  el.redirectUri.textContent = location.origin + location.pathname;
+  el.clientId.value = localStorage.getItem(STORAGE_KEYS.clientId) ?? '';
+
+  hookEvents();
+  await handleAuthRedirect();
+  renderItemList();
+  refreshAuthStatus();
+}
+
+function hookEvents() {
+  el.loginBtn.addEventListener('click', () => {
+    void startLogin();
+  });
+
+  el.logoutBtn.addEventListener('click', () => {
+    clearAuth();
+    refreshAuthStatus();
+    setPlaybackStatus('Disconnected from Spotify.');
+  });
+
+  el.addForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const parsed = parseSpotifyUri(el.itemUri.value.trim());
+    if (!parsed) {
+      setPlaybackStatus('Enter a valid Spotify album/playlist URI or URL.');
+      return;
+    }
+    const items = getItems();
+    if (items.some((item) => item.uri === parsed.uri)) {
+      setPlaybackStatus('Item is already in your list.');
+      return;
+    }
+    items.push(parsed);
+    saveItems(items);
+    el.itemUri.value = '';
+    renderItemList();
+  });
+
+  el.startBtn.addEventListener('click', () => {
+    void startShuffleSession();
+  });
+
+  el.skipBtn.addEventListener('click', () => {
+    void goToNextItem();
+  });
+
+  el.stopBtn.addEventListener('click', () => {
+    stopSession('Session stopped.');
+  });
+}
+
+function refreshAuthStatus() {
+  const token = getToken();
+  if (!token) {
+    setAuthStatus('Not connected.');
+    return;
+  }
+  const expiresMs = Number(localStorage.getItem(STORAGE_KEYS.tokenExpiry) ?? 0);
+  const minutes = Math.max(0, Math.floor((expiresMs - Date.now()) / 60000));
+  setAuthStatus(`Connected. Token expires in about ${minutes} minute(s).`);
+}
+
+/** @param {string} message */
+function setAuthStatus(message) {
+  el.authStatus.textContent = message;
+}
+
+/** @param {string} message */
+function setPlaybackStatus(message) {
+  el.playbackStatus.textContent = message;
+}
+
+async function startLogin() {
+  const clientId = el.clientId.value.trim();
+  if (!clientId) {
+    setAuthStatus('Please provide your Spotify Client ID.');
+    return;
+  }
+  localStorage.setItem(STORAGE_KEYS.clientId, clientId);
+
+  const verifier = randomString(64);
+  const challenge = await codeChallengeFromVerifier(verifier);
+  localStorage.setItem(STORAGE_KEYS.verifier, verifier);
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    scope: SCOPES.join(' '),
+    redirect_uri: location.origin + location.pathname,
+    code_challenge_method: 'S256',
+    code_challenge: challenge,
+  });
+
+  location.href = `https://accounts.spotify.com/authorize?${params.toString()}`;
+}
+
+async function handleAuthRedirect() {
+  const url = new URL(location.href);
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    setAuthStatus(`Spotify authorization error: ${error}`);
+    url.searchParams.delete('error');
+    history.replaceState({}, '', url.toString());
+    return;
+  }
+
+  if (!code) return;
+
+  const clientId = localStorage.getItem(STORAGE_KEYS.clientId);
+  const verifier = localStorage.getItem(STORAGE_KEYS.verifier);
+
+  if (!clientId || !verifier) {
+    setAuthStatus('Missing PKCE verifier/client ID. Try connecting again.');
+    return;
+  }
+
+  const formData = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: location.origin + location.pathname,
+    client_id: clientId,
+    code_verifier: verifier,
+  });
+
+  const response = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    setAuthStatus('Failed to exchange Spotify code for token.');
+    return;
+  }
+
+  /** @type {{access_token: string; expires_in: number}} */
+  const data = await response.json();
+  localStorage.setItem(STORAGE_KEYS.token, data.access_token);
+  localStorage.setItem(STORAGE_KEYS.tokenExpiry, String(Date.now() + data.expires_in * 1000));
+  localStorage.removeItem(STORAGE_KEYS.verifier);
+
+  url.searchParams.delete('code');
+  history.replaceState({}, '', url.toString());
+}
+
+function clearAuth() {
+  localStorage.removeItem(STORAGE_KEYS.token);
+  localStorage.removeItem(STORAGE_KEYS.tokenExpiry);
+  localStorage.removeItem(STORAGE_KEYS.verifier);
+}
+
+function getToken() {
+  const token = localStorage.getItem(STORAGE_KEYS.token);
+  const expiryMs = Number(localStorage.getItem(STORAGE_KEYS.tokenExpiry) ?? 0);
+  if (!token || Date.now() >= expiryMs) {
+    return null;
+  }
+  return token;
+}
+
+/** @returns {ShuffleItem[]} */
+function getItems() {
+  const raw = localStorage.getItem(STORAGE_KEYS.items);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item) =>
+        item &&
+        typeof item === 'object' &&
+        (item.type === 'album' || item.type === 'playlist') &&
+        typeof item.uri === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** @param {ShuffleItem[]} items */
+function saveItems(items) {
+  localStorage.setItem(STORAGE_KEYS.items, JSON.stringify(items));
+}
+
+function renderItemList() {
+  const items = getItems();
+  el.itemList.innerHTML = '';
+
+  for (const item of items) {
+    const li = document.createElement('li');
+    const text = document.createElement('span');
+    text.textContent = item.uri;
+
+    const actions = document.createElement('div');
+    actions.className = 'row';
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'danger';
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => {
+      saveItems(getItems().filter((candidate) => candidate.uri !== item.uri));
+      renderItemList();
+    });
+
+    actions.appendChild(removeButton);
+    li.append(text, actions);
+    el.itemList.appendChild(li);
+  }
+}
+
+async function startShuffleSession() {
+  const token = getToken();
+  if (!token) {
+    setPlaybackStatus('Connect Spotify first.');
+    return;
+  }
+
+  const items = getItems();
+  if (items.length === 0) {
+    setPlaybackStatus('Add at least one album or playlist first.');
+    return;
+  }
+
+  session.queue = shuffledCopy(items);
+  session.active = true;
+  session.index = 0;
+
+  setPlaybackStatus(`Session started with ${session.queue.length} item(s).`);
+  await playCurrentItem();
+  startMonitorLoop();
+}
+
+/** @param {string} message */
+function stopSession(message) {
+  session.active = false;
+  session.queue = [];
+  session.index = 0;
+  session.currentUri = null;
+  session.observedCurrentContext = false;
+  if (monitorTimer !== null) {
+    clearInterval(monitorTimer);
+    monitorTimer = null;
+  }
+  setPlaybackStatus(message);
+}
+
+async function goToNextItem() {
+  if (!session.active) {
+    setPlaybackStatus('No active session.');
+    return;
+  }
+
+  session.index += 1;
+  if (session.index >= session.queue.length) {
+    stopSession('Finished: all selected albums/playlists were played.');
+    return;
+  }
+
+  await playCurrentItem();
+}
+
+async function playCurrentItem() {
+  const current = session.queue[session.index];
+  session.currentUri = current.uri;
+  session.observedCurrentContext = false;
+
+  const token = getToken();
+  if (!token) {
+    stopSession('Spotify session expired. Please reconnect.');
+    return;
+  }
+
+  await spotifyApi('/me/player/shuffle?state=false', { method: 'PUT' }, token);
+  await spotifyApi('/me/player/repeat?state=off', { method: 'PUT' }, token);
+
+  await spotifyApi(
+    '/me/player/play',
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        context_uri: current.uri,
+        offset: { position: 0 },
+        position_ms: 0,
+      }),
+    },
+    token,
+  );
+
+  setPlaybackStatus(
+    `Now playing ${current.type} ${session.index + 1} of ${session.queue.length}: ${current.uri}`,
+  );
+}
+
+function startMonitorLoop() {
+  if (monitorTimer !== null) clearInterval(monitorTimer);
+  monitorTimer = window.setInterval(() => {
+    void monitorPlayback();
+  }, 4000);
+}
+
+async function monitorPlayback() {
+  if (!session.active || !session.currentUri) return;
+  const token = getToken();
+  if (!token) {
+    stopSession('Spotify session expired. Please reconnect.');
+    return;
+  }
+
+  const response = await spotifyApi('/me/player', { method: 'GET' }, token, false);
+  if (response.status === 204) {
+    // nothing currently playing/active
+    return;
+  }
+
+  /** @type {{context?: {uri?: string} | null}} */
+  const data = await response.json();
+  const contextUri = data?.context?.uri ?? null;
+
+  if (contextUri === session.currentUri) {
+    session.observedCurrentContext = true;
+    return;
+  }
+
+  if (session.observedCurrentContext && contextUri !== session.currentUri) {
+    // Current context moved away (likely finished, or user manually changed it).
+    await goToNextItem();
+  }
+}
+
+/**
+ * @param {string} path
+ * @param {RequestInit} init
+ * @param {string} token
+ * @param {boolean} throwOnError
+ */
+async function spotifyApi(path, init, token, throwOnError = true) {
+  const response = await fetch(`https://api.spotify.com/v1${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (!response.ok && throwOnError) {
+    const body = await response.text();
+    throw new Error(`Spotify API ${path} failed (${response.status}): ${body}`);
+  }
+  return response;
+}
+
+/**
+ * @param {string} raw
+ * @returns {ShuffleItem | null}
+ */
+function parseSpotifyUri(raw) {
+  if (!raw) return null;
+
+  const uriMatch = raw.match(/^spotify:(album|playlist):([a-zA-Z0-9]+)$/);
+  if (uriMatch) {
+    return { type: /** @type {ItemType} */ (uriMatch[1]), uri: raw };
+  }
+
+  try {
+    const url = new URL(raw);
+    if (!url.hostname.includes('spotify.com')) return null;
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length < 2) return null;
+
+    const [, type, id] = ['', segments[0], segments[1]];
+    if ((type === 'album' || type === 'playlist') && /^[a-zA-Z0-9]+$/.test(id)) {
+      return { type, uri: `spotify:${type}:${id}` };
+    }
+  } catch {
+    // not a URL
+  }
+
+  return null;
+}
+
+/** @param {ShuffleItem[]} values */
+function shuffledCopy(values) {
+  const out = [...values];
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** @param {number} length */
+function randomString(length) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let text = '';
+  const randomValues = crypto.getRandomValues(new Uint8Array(length));
+  for (const value of randomValues) {
+    text += chars[value % chars.length];
+  }
+  return text;
+}
+
+/** @param {string} verifier */
+async function codeChallengeFromVerifier(verifier) {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(digest);
+
+  let str = '';
+  for (const byte of bytes) str += String.fromCharCode(byte);
+
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spotify Collection Shuffler</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Spotify Album + Playlist Shuffler</h1>
+      <p>
+        Randomly cycles through your saved set of Spotify albums/playlists while keeping
+        each item's tracks in order.
+      </p>
+
+      <section class="panel">
+        <h2>1) Connect Spotify</h2>
+        <label>
+          Spotify Client ID
+          <input id="client-id" placeholder="Your Spotify app client ID" />
+        </label>
+        <p class="small">
+          In your Spotify app settings, add this redirect URI:
+          <code id="redirect-uri"></code>
+        </p>
+        <div class="row">
+          <button id="login-btn">Connect</button>
+          <button id="logout-btn" class="secondary">Disconnect</button>
+        </div>
+        <p id="auth-status" class="small" aria-live="polite"></p>
+      </section>
+
+      <section class="panel">
+        <h2>2) Manage Album/Playlist List</h2>
+        <form id="add-form" class="row">
+          <input
+            id="item-uri"
+            placeholder="spotify:album:... or spotify:playlist:..."
+            required
+          />
+          <button type="submit">Add</button>
+        </form>
+        <p class="small">
+          Tip: You can paste a normal Spotify URL and it will be converted.
+        </p>
+        <ul id="item-list"></ul>
+      </section>
+
+      <section class="panel">
+        <h2>3) Start Shuffle Session</h2>
+        <div class="row">
+          <button id="start-btn">Start</button>
+          <button id="skip-btn" class="secondary">Skip To Next</button>
+          <button id="stop-btn" class="danger">Stop</button>
+        </div>
+        <p id="playback-status" aria-live="polite"></p>
+      </section>
+    </main>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["./*.js"]
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,88 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+}
+
+main {
+  max-width: 880px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.panel {
+  border: 1px solid color-mix(in oklab, canvasText 30%, canvas 70%);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+label,
+input,
+button {
+  font: inherit;
+}
+
+label {
+  display: grid;
+  gap: 0.3rem;
+}
+
+input {
+  min-width: 320px;
+  max-width: 100%;
+  padding: 0.45rem;
+}
+
+button {
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in oklab, canvasText 35%, canvas 65%);
+  cursor: pointer;
+}
+
+button.secondary {
+  opacity: 0.9;
+}
+
+button.danger {
+  border-color: #b53939;
+}
+
+.small {
+  opacity: 0.86;
+  font-size: 0.9rem;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4rem;
+  border: 1px solid color-mix(in oklab, canvasText 25%, canvas 75%);
+  border-radius: 0.5rem;
+}
+
+code {
+  user-select: all;
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, static web app that lets a user shuffle between selected Spotify albums/playlists and have each context play its tracks in order before advancing.
- Keep the app deployable without a build step by using plain JS with JSDoc and the TypeScript compiler for type checking.
- Request only the minimal Spotify scopes required to control and monitor playback.

### Description
- Add a static UI in `index.html` and styling in `styles.css` for Spotify connection, item management, and session controls. 
- Implement browser-only Spotify PKCE OAuth, token storage/expiry handling, album/playlist URI parsing and persistence in `localStorage`, shuffle/session logic, playback control (`/me/player/play`, shuffle/repeat toggles), and a monitor loop to advance contexts in `app.js`.
- Add `jsconfig.json` to enable strict JSDoc-based type checking with `tsc` and include a `README.md` with run instructions and the minimal requested scopes (`user-modify-playback-state`, `user-read-playback-state`).
- Add JSDoc `@param` annotations for a few functions to satisfy the TypeScript checks.

### Testing
- Ran `tsc -p jsconfig.json`; initial run surfaced implicit `any` errors which were fixed by adding JSDoc `@param` annotations. The final `tsc -p jsconfig.json` run completed successfully. 
- No other automated runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1b38b5b088321821f4ae5d53de418)