### PR TITLE
Add GitHub Action to run typecheck on every push

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,25 @@
+name: Typecheck
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install TypeScript
+        run: npm install --no-save typescript
+
+      - name: Run typecheck
+        run: npx tsc -p jsconfig.json


### PR DESCRIPTION
### Motivation
- Ensure JavaScript type checking runs automatically on every push across all branches to catch type issues early.

### Description
- Add a new workflow at `.github/workflows/typecheck.yml` that triggers on `push` for all branches and runs a `typecheck` job which checks out the repo, sets up Node.js 20, installs TypeScript, and runs `npx tsc -p jsconfig.json`.

### Testing
- Ran `tsc -p jsconfig.json` locally which succeeded, and attempted `npx --yes typescript tsc -p jsconfig.json` which failed in this environment due to npm registry access returning 403.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1ddb752608321be6773fca3a5445d)