### PR TITLE
Refresh access token during bootstrap to avoid false "Not connected" state

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,9 +86,19 @@ async function bootstrap() {
   hookEvents();
   restoreRuntimeState();
   await handleAuthRedirect();
+  await ensureValidAccessToken();
   renderItemList();
   refreshAuthStatus();
   await ensureStoredItemTitles();
+}
+
+async function ensureValidAccessToken() {
+  if (getToken()) return;
+
+  const hasRefreshToken = Boolean(localStorage.getItem(STORAGE_KEYS.refreshToken));
+  if (!hasRefreshToken) return;
+
+  await refreshSpotifyAccessToken();
 }
 
 function hookEvents() {


### PR DESCRIPTION
### Motivation
- When reloading the page with an expired access token but a stored refresh token the UI could show `Not connected.` even though an access token refresh is possible, so the app should attempt a refresh during startup to reflect the true connection state.

### Description
- Add `ensureValidAccessToken()` which calls `refreshSpotifyAccessToken()` when `getToken()` is missing but a refresh token exists, and invoke it from `bootstrap()` after `handleAuthRedirect()` so auth status is validated before rendering.

### Testing
- Ran `node --check app.js` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c321ac73048321a3b82f858467a4cd)