### PR TITLE
Show active shuffle queue as list

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ const el = {
   skipBtn: /** @type {HTMLButtonElement} */ (document.getElementById('skip-btn')),
   stopBtn: /** @type {HTMLButtonElement} */ (document.getElementById('stop-btn')),
   playbackStatus: /** @type {HTMLParagraphElement} */ (document.getElementById('playback-status')),
+  queueList: /** @type {HTMLUListElement} */ (document.getElementById('queue-list')),
   exportStorageBtn: /** @type {HTMLButtonElement} */ (
     document.getElementById('export-storage-btn')
   ),
@@ -88,6 +89,7 @@ async function bootstrap() {
   await handleAuthRedirect();
   await ensureValidAccessToken();
   renderItemList();
+  renderSessionQueue();
   refreshAuthStatus();
   await ensureStoredItemTitles();
 }
@@ -482,6 +484,7 @@ async function startShuffleSession() {
   session.active = true;
   session.index = 0;
   persistRuntimeState();
+  renderSessionQueue();
 
   setPlaybackStatus(`Session started with ${session.queue.length} item(s).`);
   await playCurrentItem();
@@ -500,6 +503,7 @@ function stopSession(message) {
     clearInterval(monitorTimer);
     monitorTimer = null;
   }
+  renderSessionQueue();
   setPlaybackStatus(message);
 }
 
@@ -515,6 +519,7 @@ async function goToNextItem() {
     stopSession('Finished: all selected albums/playlists were played.');
     return;
   }
+  renderSessionQueue();
 
   await playCurrentItem();
 }
@@ -768,6 +773,7 @@ function restoreRuntimeState() {
 
   const current = session.queue[session.index];
   setPlaybackStatus(formatNowPlayingStatus(current));
+  renderSessionQueue();
   startMonitorLoop();
 }
 
@@ -786,6 +792,22 @@ function persistRuntimeState() {
 
 function clearRuntimeState() {
   localStorage.removeItem(STORAGE_KEYS.runtime);
+}
+
+function renderSessionQueue() {
+  el.queueList.innerHTML = '';
+  if (!session.active || session.queue.length === 0) return;
+
+  for (let i = 0; i < session.queue.length; i += 1) {
+    const item = session.queue[i];
+    const li = document.createElement('li');
+    if (i === session.index) {
+      li.classList.add('current');
+    }
+    const marker = i === session.index ? '▶' : '•';
+    li.textContent = `${marker} ${i + 1}. ${item.title} (${item.type})`;
+    el.queueList.appendChild(li);
+  }
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
           <button id="stop-btn" class="danger">Stop</button>
         </div>
         <p id="playback-status" aria-live="polite"></p>
+        <ul id="queue-list" aria-live="polite"></ul>
       </section>
 
       <section class="panel">

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,19 @@ ul {
   border-radius: 0.5rem;
 }
 
+#queue-list {
+  margin-top: 0.75rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border: 1px solid color-mix(in oklab, canvasText 30%, canvas 70%);
+  border-radius: 0.5rem;
+}
+
+#queue-list li.current {
+  border-color: color-mix(in oklab, #2f7dd6 75%, canvas 25%);
+}
+
 li {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
### Motivation
- Make the active shuffled order visible to the user so they can see upcoming items and the current item while a session is running.

### Description
- Added a queue container to the UI as `#queue-list` under the playback status in `index.html`.
- Added a `queueList` DOM reference and implemented `renderSessionQueue()` in `app.js` to render the session `queue`, show numeric ordering, and mark the current item with a `▶` marker and a `current` class.
- Wired `renderSessionQueue()` into session lifecycle points including `bootstrap`, session start, skip/advance, stop, and runtime restore so the list stays in sync with playback state.
- Added styles for `#queue-list` and a `.current` highlight in `styles.css` to improve readability.

### Testing
- Ran `node --check app.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c323f250d48321a0cdea8ce9176bc2)