### PR TITLE
Remove Spotify token lifetime from auth status display

### DIFF
--- a/app.js
+++ b/app.js
@@ -170,8 +170,6 @@ function refreshAuthStatus() {
     setAuthStatus('Not connected.');
     return;
   }
-  const expiresMs = Number(localStorage.getItem(STORAGE_KEYS.tokenExpiry) ?? 0);
-  const minutes = Math.max(0, Math.floor((expiresMs - Date.now()) / 60000));
   const scopeSet = getGrantedScopes();
   if (!scopeSet.has('playlist-read-private') || !scopeSet.has('playlist-read-collaborative')) {
     setAuthStatus(
@@ -179,7 +177,7 @@ function refreshAuthStatus() {
     );
     return;
   }
-  setAuthStatus(`Connected. Token expires in about ${minutes} minute(s).`);
+  setAuthStatus('Connected.');
 }
 
 function getGrantedScopes() {


### PR DESCRIPTION
### Motivation
- Stop displaying a calculated countdown of the Spotify access token lifetime in the UI and retain only the connection / scope status to avoid showing a possibly stale expiry estimate.

### Description
- Updated `refreshAuthStatus()` in `app.js` to remove the `tokenExpiry` lookup and minute calculation and to show a simple `Connected.` message while preserving the existing missing-scope warning.

### Testing
- Ran `node --check app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c44e028cac8321884619904666af8b)