### PR TITLE
Add toast notifications and reserve playback status for session state

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ const el = {
     document.getElementById('import-storage-btn')
   ),
   storageJson: /** @type {HTMLTextAreaElement} */ (document.getElementById('storage-json')),
+  toastStack: /** @type {HTMLDivElement} */ (document.getElementById('toast-stack')),
 };
 
 /** @type {SessionState} */
@@ -74,6 +75,7 @@ const session = {
 };
 
 let monitorTimer = /** @type {number | null} */ (null);
+const TOAST_DURATION_MS = 5000;
 
 bootstrap().catch((error) => {
   console.error(error);
@@ -106,30 +108,30 @@ function hookEvents() {
   el.logoutBtn.addEventListener('click', () => {
     clearAuth();
     refreshAuthStatus();
-    setPlaybackStatus('Disconnected from Spotify.');
+    showToast('Disconnected from Spotify.', 'info');
   });
 
   el.addForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     const parsed = parseSpotifyUri(el.itemUri.value.trim());
     if (!parsed) {
-      setPlaybackStatus('Enter a valid Spotify album/playlist URI or URL.');
+      showToast('Enter a valid Spotify album/playlist URI or URL.', 'error');
       return;
     }
     const items = getItems();
     if (items.some((item) => item.uri === parsed.uri)) {
-      setPlaybackStatus('Item is already in your list.');
+      showToast('Item is already in your list.', 'info');
       return;
     }
     const token = await getUsableAccessToken();
     if (!token) {
-      setPlaybackStatus('Connect Spotify first so the app can load item titles.');
+      showToast('Connect Spotify first so the app can load item titles.', 'error');
       return;
     }
 
     const titledItem = await withItemTitle(parsed, token);
     if (!titledItem) {
-      setPlaybackStatus('Unable to load title for that item. Please try another URI.');
+      showToast('Unable to load title for that item. Please try another URI.', 'error');
       return;
     }
 
@@ -137,6 +139,7 @@ function hookEvents() {
     saveItems(items);
     el.itemUri.value = '';
     renderItemList();
+    showToast('Item added.', 'success');
   });
 
   el.startBtn.addEventListener('click', () => {
@@ -223,6 +226,57 @@ function setAuthStatus(message) {
 /** @param {string} message */
 function setPlaybackStatus(message) {
   el.playbackStatus.textContent = message;
+}
+
+
+/**
+ * @param {string} message
+ * @param {'success' | 'info' | 'error'} [type]
+ */
+function showToast(message, type = 'info') {
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${type}`;
+  toast.role = type === 'error' ? 'alert' : 'status';
+
+  const body = document.createElement('span');
+  body.className = 'toast-message';
+  body.textContent = message;
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'toast-close';
+  closeButton.setAttribute('aria-label', 'Close notification');
+  closeButton.textContent = '×';
+
+  /** @type {number | null} */
+  let timeoutId = window.setTimeout(removeToast, TOAST_DURATION_MS);
+
+  function clearDismissTimer() {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  }
+
+  function restartDismissTimer() {
+    clearDismissTimer();
+    timeoutId = window.setTimeout(removeToast, TOAST_DURATION_MS);
+  }
+
+  function removeToast() {
+    clearDismissTimer();
+    toast.classList.add('toast-leaving');
+    window.setTimeout(() => {
+      toast.remove();
+    }, 180);
+  }
+
+  closeButton.addEventListener('click', removeToast);
+  toast.addEventListener('mouseenter', clearDismissTimer);
+  toast.addEventListener('mouseleave', restartDismissTimer);
+
+  toast.append(body, closeButton);
+  el.toastStack.appendChild(toast);
 }
 
 async function startLogin() {
@@ -355,13 +409,13 @@ function exportLocalStorageJson() {
   }
 
   el.storageJson.value = JSON.stringify(data, null, 2);
-  setPlaybackStatus(`Exported ${Object.keys(data).length} local storage key(s) to JSON.`);
+  showToast(`Exported ${Object.keys(data).length} local storage key(s) to JSON.`, 'success');
 }
 
 function importLocalStorageJson() {
   const raw = el.storageJson.value.trim();
   if (!raw) {
-    setPlaybackStatus('Paste a JSON object to import.');
+    showToast('Paste a JSON object to import.', 'error');
     return;
   }
 
@@ -370,12 +424,12 @@ function importLocalStorageJson() {
   try {
     parsed = JSON.parse(raw);
   } catch {
-    setPlaybackStatus('Invalid JSON. Please provide a valid JSON object.');
+    showToast('Invalid JSON. Please provide a valid JSON object.', 'error');
     return;
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    setPlaybackStatus('Import JSON must be an object of key/value pairs.');
+    showToast('Import JSON must be an object of key/value pairs.', 'error');
     return;
   }
 
@@ -390,7 +444,7 @@ function importLocalStorageJson() {
   el.clientId.value = localStorage.getItem(STORAGE_KEYS.clientId) ?? '';
   renderItemList();
   refreshAuthStatus();
-  setPlaybackStatus(`Imported ${entries.length} local storage key(s).`);
+  showToast(`Imported ${entries.length} local storage key(s).`, 'success');
 }
 
 function getToken() {
@@ -473,13 +527,13 @@ function renderItemList() {
 async function startShuffleSession() {
   const token = await getUsableAccessToken();
   if (!token) {
-    setPlaybackStatus('Connect Spotify first.');
+    showToast('Connect Spotify first.', 'error');
     return;
   }
 
   const items = getItems();
   if (items.length === 0) {
-    setPlaybackStatus('Add at least one album or playlist first.');
+    showToast('Add at least one album or playlist first.', 'info');
     return;
   }
 
@@ -561,23 +615,23 @@ async function playCurrentItem() {
 async function importAlbumsFromPlaylist() {
   const token = await getUsableAccessToken();
   if (!token) {
-    setPlaybackStatus('Connect Spotify first so the app can import albums.');
+    showToast('Connect Spotify first so the app can import albums.', 'error');
     return;
   }
 
   const parsedPlaylist = parseSpotifyPlaylistRef(el.itemUri.value.trim());
   if (!parsedPlaylist) {
-    setPlaybackStatus('Enter a valid Spotify playlist URL, URI, or playlist ID.');
+    showToast('Enter a valid Spotify playlist URL, URI, or playlist ID.', 'error');
     return;
   }
 
-  setPlaybackStatus('Importing albums from playlist...');
+  showToast('Importing albums from playlist...', 'info');
 
   const existingItems = getItems();
   const existingUris = new Set(existingItems.map((item) => item.uri));
   const importResult = await fetchPlaylistAlbums(parsedPlaylist.id, token);
   if (importResult.errorMessage) {
-    setPlaybackStatus(importResult.errorMessage);
+    showToast(importResult.errorMessage, 'error');
     return;
   }
   const albumsFromPlaylist = importResult.albums;
@@ -592,8 +646,9 @@ async function importAlbumsFromPlaylist() {
 
   saveItems(existingItems);
   renderItemList();
-  setPlaybackStatus(
+  showToast(
     `Imported ${added} album(s) from playlist (${albumsFromPlaylist.length} unique album(s) found).`,
+    'success',
   );
 }
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,8 @@
       </section>
     </main>
 
+    <div id="toast-stack" aria-live="polite" aria-atomic="false"></div>
+
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -115,3 +115,76 @@ li {
 code {
   user-select: all;
 }
+
+#toast-stack {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  display: grid;
+  gap: 0.6rem;
+  width: min(24rem, calc(100vw - 2rem));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid;
+  background: color-mix(in oklab, canvas 88%, canvasText 12%);
+  box-shadow: 0 10px 20px color-mix(in oklab, canvasText 18%, transparent);
+  animation: toast-enter 0.2s ease-out;
+}
+
+.toast-message {
+  line-height: 1.3;
+}
+
+.toast-close {
+  line-height: 1;
+  min-width: 1.8rem;
+  padding: 0.15rem 0.45rem;
+}
+
+.toast-info {
+  border-color: #3a76c5;
+}
+
+.toast-success {
+  border-color: #2e9f67;
+}
+
+.toast-error {
+  border-color: #bf3d3d;
+}
+
+.toast-leaving {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+@keyframes toast-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 640px) {
+  #toast-stack {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: auto;
+  }
+}


### PR DESCRIPTION
### Motivation

- Separate transient UI messages from playback/session state so status text remains focused on now-playing and session lifecycle.
- Provide a lightweight, accessible notification mechanism for input validation, import/export, auth, and other non-playback events.

### Description

- Added a toast container to `index.html` as `<div id="toast-stack" aria-live="polite" aria-atomic="false"></div>` to host stacked notifications.
- Implemented `showToast(message, type)` in `app.js` with `TOAST_DURATION_MS`, hover pause/resume, manual close button, ARIA roles (`alert` for errors), and appended `el.toastStack` reference.
- Re-routed non-playback calls that previously used `setPlaybackStatus(...)` to `showToast(...)` for input validation, import/export, auth-related, and playlist-import messages while keeping `setPlaybackStatus(...)` strictly for playback/session state (start/stop/now-playing).
- Added toast styles to `styles.css` including `info`/`success`/`error` variants, stacking layout, enter/exit transitions, close button styling, and responsive positioning.

### Testing

- Ran `node --check app.js` to verify JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c45481341083218cc12a5e8b6b063c)