### PR TITLE
Remove album/playlist type suffixes from UI labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -575,7 +575,7 @@ function renderItemList() {
   for (const item of items) {
     const li = document.createElement('li');
     const text = document.createElement('span');
-    text.textContent = item.title ? `${item.title} (${item.type})` : `${item.uri} (${item.type})`;
+    text.textContent = item.title ? item.title : item.uri;
 
     const actions = document.createElement('div');
     actions.className = 'row';
@@ -976,7 +976,7 @@ function renderSessionQueue() {
       li.classList.add('current');
     }
     const marker = i === session.index ? '▶' : '•';
-    li.textContent = `${marker} ${i + 1}. ${item.title} (${item.type})`;
+    li.textContent = `${marker} ${i + 1}. ${item.title}`;
     el.queueList.appendChild(li);
   }
 }


### PR DESCRIPTION
### Motivation
- Remove the explicit `(album)` / `(playlist)` suffix from displayed items to simplify the UI and avoid redundant type labels in the saved-items list and active queue.

### Description
- Update `renderItemList` and `renderSessionQueue` in `app.js` to render `item.title` (or fallback `item.uri`) without appending ` (${item.type})`.

### Testing
- Ran `rg -n "\(album\)|\(playlist\)" app.js index.html styles.css README.md` to confirm the suffixes were removed and inspected the change with `git show --stat --oneline -1`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c48cf3882883218051740da8717bb8)