### PR TITLE
Add undo banner after removing items

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,6 +80,8 @@ const ERROR_TOAST_COOLDOWN_MS = 45000;
 /** @type {Map<string, number>} */
 const errorToastLastShownAt = new Map();
 
+/** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
+
 bootstrap().catch((error) => {
   reportError(error, {
     context: 'startup',
@@ -291,8 +293,9 @@ function setPlaybackStatus(message) {
 /**
  * @param {string} message
  * @param {'success' | 'info' | 'error'} [type]
+ * @param {{ action?: ToastAction }} [options]
  */
-function showToast(message, type = 'info') {
+function showToast(message, type = 'info', options = {}) {
   const toast = document.createElement('div');
   toast.className = `toast toast-${type}`;
   toast.role = type === 'error' ? 'alert' : 'status';
@@ -306,6 +309,22 @@ function showToast(message, type = 'info') {
   closeButton.className = 'toast-close';
   closeButton.setAttribute('aria-label', 'Close notification');
   closeButton.textContent = '×';
+
+  const actions = document.createElement('div');
+  actions.className = 'toast-actions';
+
+  if (options.action) {
+    const actionButton = document.createElement('button');
+    actionButton.type = 'button';
+    actionButton.className = 'secondary toast-action';
+    actionButton.textContent = options.action.actionLabel;
+    actionButton.addEventListener('click', () => {
+      options.action?.onAction();
+      removeToast();
+    });
+    actions.appendChild(actionButton);
+  }
+  actions.appendChild(closeButton);
 
   /** @type {number | null} */
   let timeoutId = window.setTimeout(removeToast, TOAST_DURATION_MS);
@@ -334,7 +353,7 @@ function showToast(message, type = 'info') {
   toast.addEventListener('mouseenter', clearDismissTimer);
   toast.addEventListener('mouseleave', restartDismissTimer);
 
-  toast.append(body, closeButton);
+  toast.append(body, actions);
   el.toastStack.appendChild(toast);
 }
 
@@ -585,8 +604,34 @@ function renderItemList() {
     removeButton.className = 'danger';
     removeButton.textContent = 'Remove';
     removeButton.addEventListener('click', () => {
-      saveItems(getItems().filter((candidate) => candidate.uri !== item.uri));
+      const items = getItems();
+      const removedIndex = items.findIndex((candidate) => candidate.uri === item.uri);
+      if (removedIndex < 0) return;
+
+      const [removedItem] = items.splice(removedIndex, 1);
+      saveItems(items);
       renderItemList();
+
+      showToast(`Removed “${removedItem.title}”.`, 'info', {
+        action: {
+          actionLabel: 'Undo',
+          onAction: () => {
+            const restoredItems = getItems();
+            const existingIndex = restoredItems.findIndex(
+              (candidate) => candidate.uri === removedItem.uri,
+            );
+            if (existingIndex >= 0) {
+              showToast('Item is already in your list.', 'info');
+              return;
+            }
+
+            restoredItems.splice(removedIndex, 0, removedItem);
+            saveItems(restoredItems);
+            renderItemList();
+            showToast(`Restored “${removedItem.title}”.`, 'success');
+          },
+        },
+      });
     });
 
     actions.appendChild(removeButton);

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,16 @@ code {
   padding: 0.15rem 0.45rem;
 }
 
+.toast-actions {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.toast-action {
+  padding: 0.15rem 0.55rem;
+}
+
 .toast-info {
   border-color: #3a76c5;
 }


### PR DESCRIPTION
### Motivation
- Users should be able to undo accidental removals from the item list by offering a temporary banner with an Undo action after removal.
- The existing toast system should be extended to support inline actions so the UI can present contextual operations like Undo.

### Description
- Added optional action support to `showToast(message, type, options)` and rendered a `.toast-actions` container with an action button that invokes a provided callback in `app.js`.
- Updated the remove button handler in `renderItemList()` to remove the item immediately, show an informational toast with an `Undo` action, and restore the removed item at its original index when Undo is clicked in `app.js`.
- Added minimal styles for the toast action area and action button in `styles.css` to match existing toast layout and behavior.

### Testing
- Ran `node --check app.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4b60fd7dc8321bef991cd2f0f9719)