### PR TITLE
Add workflow to enforce Codex co-author trailers on codex/* PRs

### DIFF
--- a/.github/workflows/codex-coauthor-check.yml
+++ b/.github/workflows/codex-coauthor-check.yml
@@ -1,0 +1,51 @@
+name: Codex Co-Author Trailer Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  verify-codex-coauthor-trailer:
+    if: startsWith(github.event.pull_request.head.ref, 'codex/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify commit trailers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t commits < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
+
+          if [ "${#commits[@]}" -eq 0 ]; then
+            echo "No commits found between ${BASE_SHA} and ${HEAD_SHA}."
+            exit 0
+          fi
+
+          missing=0
+
+          for commit in "${commits[@]}"; do
+            message="$(git show -s --format=%B "$commit")"
+
+            if ! printf '%s\n' "$message" | grep -q '^Co-Authored-By: Codex <codex@openai.com>$'; then
+              echo "Commit $commit is missing required trailer: Co-Authored-By: Codex <codex@openai.com>"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "One or more commits are missing the required trailer."
+            exit 1
+          fi
+
+          echo "All commits include the required Codex co-author trailer."


### PR DESCRIPTION
### Motivation
- Ensure PRs created from branches whose names start with `codex/` always include the co-author trailer `Co-Authored-By: Codex <codex@openai.com>` on every commit in the PR range.
- Prevent merged histories from missing the required Codex co-author attribution by failing PR CI when any commit is missing the trailer.

### Description
- Add a GitHub Actions workflow at `.github/workflows/codex-coauthor-check.yml` that runs on `pull_request` events `opened`, `reopened`, and `synchronize`.
- Scope the job with a job-level condition `if: startsWith(github.event.pull_request.head.ref, 'codex/')` so it only runs for source branches beginning with `codex/`.
- Checkout with `actions/checkout@v4` (`fetch-depth: 0`) and verify the commit range `BASE_SHA..HEAD_SHA` using `git rev-list`, then check each commit message with `grep` for the exact trailer `Co-Authored-By: Codex <codex@openai.com>` and fail the job if any commit is missing it.

### Testing
- Inspected the new workflow file contents with `nl -ba .github/workflows/codex-coauthor-check.yml`, which showed the expected steps and logic. 
- Verified repository status with `git status --short` to confirm the workflow file is present. 
- No GitHub Actions run was executed locally; the workflow will execute on GitHub for qualifying pull request events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c575ddc6b483219f7f58bc51d11eb3)