### PR TITLE
Improve JSDoc typing for full type-coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -588,25 +588,25 @@ function getItems() {
     const parsedItems = parsed;
     return parsedItems
       .filter(
-        /** @param {unknown} item */
-        (item) =>
-          item &&
-          typeof item === 'object' &&
-          (item.type === 'album' || item.type === 'playlist') &&
-          typeof item.uri === 'string',
-      )
-      .map(
-        /** @param {unknown} item */
+        /**
+         * @param {unknown} item
+         * @returns {item is {type: ItemType; uri: string; title?: unknown}}
+         */
         (item) => {
-        /** @type {{type: ItemType; uri: string; title?: unknown}} */
-        const parsedItem = /** @type {{type: ItemType; uri: string; title?: unknown}} */ (item);
-        return {
-          type: parsedItem.type,
-          uri: parsedItem.uri,
-          title: typeof parsedItem.title === 'string' ? parsedItem.title : parsedItem.uri,
-        };
+          if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+          /** @type {Record<string, unknown>} */
+          const parsedItem = /** @type {Record<string, unknown>} */ (item);
+          return (
+            (parsedItem.type === 'album' || parsedItem.type === 'playlist') &&
+            typeof parsedItem.uri === 'string'
+          );
         },
-      );
+      )
+      .map((item) => ({
+        type: item.type,
+        uri: item.uri,
+        title: typeof item.title === 'string' ? item.title : item.uri,
+      }));
   } catch {
     return [];
   }
@@ -989,7 +989,10 @@ function restoreRuntimeState() {
   const queueItems = Array.isArray(queueValue) ? queueValue : [];
   /** @type {ShuffleItem[]} */
   const restoredQueue = queueItems.filter(
-        /** @param {unknown} item */
+        /**
+         * @param {unknown} item
+         * @returns {item is ShuffleItem}
+         */
         (item) => {
           if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
           /** @type {Record<string, unknown>} */

--- a/app.js
+++ b/app.js
@@ -82,7 +82,9 @@ const errorToastLastShownAt = new Map();
 
 /** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
 
-bootstrap().catch((error) => {
+bootstrap().catch(
+  /** @param {unknown} error */
+  (error) => {
   reportError(error, {
     context: 'startup',
     fallbackMessage: 'The app failed to initialize.',
@@ -90,7 +92,8 @@ bootstrap().catch((error) => {
     toastMode: 'cooldown',
     toastKey: 'startup',
   });
-});
+  },
+);
 
 async function bootstrap() {
   el.redirectUri.textContent = location.origin + location.pathname;
@@ -122,13 +125,16 @@ async function ensureValidAccessToken() {
 
 function hookEvents() {
   el.loginBtn.addEventListener('click', () => {
-    void startLogin().catch((error) => {
+    void startLogin().catch(
+      /** @param {unknown} error */
+      (error) => {
       reportError(error, {
         context: 'auth',
         fallbackMessage: 'Failed to start Spotify connection.',
         authStatusMessage: 'Unable to connect right now. Please try again.',
       });
-    });
+      },
+    );
   });
 
   el.logoutBtn.addEventListener('click', () => {
@@ -176,32 +182,41 @@ function hookEvents() {
   });
 
   el.startBtn.addEventListener('click', () => {
-    void startShuffleSession().catch((error) => {
+    void startShuffleSession().catch(
+      /** @param {unknown} error */
+      (error) => {
       reportError(error, {
         context: 'playback',
         fallbackMessage: 'Failed to start shuffle session.',
         playbackStatusMessage: 'Unable to start session right now. Please try again.',
       });
-    });
+      },
+    );
   });
 
   el.importPlaylistBtn.addEventListener('click', () => {
-    void importAlbumsFromPlaylist().catch((error) => {
+    void importAlbumsFromPlaylist().catch(
+      /** @param {unknown} error */
+      (error) => {
       reportError(error, {
         context: 'import',
         fallbackMessage: 'Failed to import albums from playlist.',
       });
-    });
+      },
+    );
   });
 
   el.skipBtn.addEventListener('click', () => {
-    void goToNextItem().catch((error) => {
+    void goToNextItem().catch(
+      /** @param {unknown} error */
+      (error) => {
       reportError(error, {
         context: 'playback',
         fallbackMessage: 'Failed to skip to the next item.',
         playbackStatusMessage: 'Unable to skip right now. Please try again.',
       });
-    });
+      },
+    );
   });
 
   el.stopBtn.addEventListener('click', () => {
@@ -242,6 +257,7 @@ async function ensureStoredItemTitles() {
   const items = getItems();
   if (items.length === 0) return;
 
+  /** @type {string | null} */
   let token = null;
   try {
     token = await getUsableAccessToken();
@@ -257,6 +273,7 @@ async function ensureStoredItemTitles() {
   if (!token) return;
 
   let changed = false;
+  /** @type {ShuffleItem[]} */
   const updated = [];
   for (const item of items) {
     if (item.title) {
@@ -456,6 +473,7 @@ async function refreshSpotifyAccessToken() {
     client_id: clientId,
   });
 
+  /** @type {Response} */
   let response;
   try {
     response = await fetch('https://accounts.spotify.com/api/token', {
@@ -523,6 +541,7 @@ function importLocalStorageJson() {
     return;
   }
 
+  /** @type {[string, unknown][]} */
   const entries = Object.entries(parsed);
   localStorage.clear();
   for (const [key, value] of entries) {
@@ -562,21 +581,32 @@ function getItems() {
   if (!raw) return [];
 
   try {
+    /** @type {unknown} */
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed
+    /** @type {unknown[]} */
+    const parsedItems = parsed;
+    return parsedItems
       .filter(
+        /** @param {unknown} item */
         (item) =>
           item &&
           typeof item === 'object' &&
           (item.type === 'album' || item.type === 'playlist') &&
           typeof item.uri === 'string',
       )
-      .map((item) => ({
-        type: item.type,
-        uri: item.uri,
-        title: typeof item.title === 'string' ? item.title : item.uri,
-      }));
+      .map(
+        /** @param {unknown} item */
+        (item) => {
+        /** @type {{type: ItemType; uri: string; title?: unknown}} */
+        const parsedItem = /** @type {{type: ItemType; uri: string; title?: unknown}} */ (item);
+        return {
+          type: parsedItem.type,
+          uri: parsedItem.uri,
+          title: typeof parsedItem.title === 'string' ? parsedItem.title : parsedItem.uri,
+        };
+        },
+      );
   } catch {
     return [];
   }
@@ -864,7 +894,9 @@ function spotifyIdFromUri(uri) {
 function startMonitorLoop() {
   if (monitorTimer !== null) clearInterval(monitorTimer);
   monitorTimer = window.setInterval(() => {
-    void monitorPlayback().catch((error) => {
+    void monitorPlayback().catch(
+      /** @param {unknown} error */
+      (error) => {
       reportError(error, {
         context: 'monitor',
         fallbackMessage: 'Playback monitor encountered an error.',
@@ -872,7 +904,8 @@ function startMonitorLoop() {
         toastMode: 'cooldown',
         toastKey: 'monitor-loop',
       });
-    });
+      },
+    );
   }, 4000);
 }
 
@@ -950,9 +983,12 @@ function restoreRuntimeState() {
   /** @type {Record<string, unknown>} */
   const parsed = /** @type {Record<string, unknown>} */ (parsedUnknown);
 
+  /** @type {unknown} */
   const queueValue = parsed.queue;
-  const restoredQueue = Array.isArray(queueValue)
-    ? queueValue.filter(
+  /** @type {unknown[]} */
+  const queueItems = Array.isArray(queueValue) ? queueValue : [];
+  /** @type {ShuffleItem[]} */
+  const restoredQueue = queueItems.filter(
         /** @param {unknown} item */
         (item) => {
           if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
@@ -964,8 +1000,7 @@ function restoreRuntimeState() {
             typeof runtimeItem.title === 'string'
           );
         },
-      )
-    : [];
+      );
 
   const indexValue = parsed.index;
   const restoredIndex =

--- a/app.js
+++ b/app.js
@@ -85,13 +85,13 @@ const errorToastLastShownAt = new Map();
 bootstrap().catch(
   /** @param {unknown} error */
   (error) => {
-  reportError(error, {
-    context: 'startup',
-    fallbackMessage: 'The app failed to initialize.',
-    authStatusMessage: 'Startup failed. Please refresh and reconnect Spotify.',
-    toastMode: 'cooldown',
-    toastKey: 'startup',
-  });
+    reportError(error, {
+      context: 'startup',
+      fallbackMessage: 'The app failed to initialize.',
+      authStatusMessage: 'Startup failed. Please refresh and reconnect Spotify.',
+      toastMode: 'cooldown',
+      toastKey: 'startup',
+    });
   },
 );
 
@@ -128,11 +128,11 @@ function hookEvents() {
     void startLogin().catch(
       /** @param {unknown} error */
       (error) => {
-      reportError(error, {
-        context: 'auth',
-        fallbackMessage: 'Failed to start Spotify connection.',
-        authStatusMessage: 'Unable to connect right now. Please try again.',
-      });
+        reportError(error, {
+          context: 'auth',
+          fallbackMessage: 'Failed to start Spotify connection.',
+          authStatusMessage: 'Unable to connect right now. Please try again.',
+        });
       },
     );
   });
@@ -185,11 +185,11 @@ function hookEvents() {
     void startShuffleSession().catch(
       /** @param {unknown} error */
       (error) => {
-      reportError(error, {
-        context: 'playback',
-        fallbackMessage: 'Failed to start shuffle session.',
-        playbackStatusMessage: 'Unable to start session right now. Please try again.',
-      });
+        reportError(error, {
+          context: 'playback',
+          fallbackMessage: 'Failed to start shuffle session.',
+          playbackStatusMessage: 'Unable to start session right now. Please try again.',
+        });
       },
     );
   });
@@ -198,10 +198,10 @@ function hookEvents() {
     void importAlbumsFromPlaylist().catch(
       /** @param {unknown} error */
       (error) => {
-      reportError(error, {
-        context: 'import',
-        fallbackMessage: 'Failed to import albums from playlist.',
-      });
+        reportError(error, {
+          context: 'import',
+          fallbackMessage: 'Failed to import albums from playlist.',
+        });
       },
     );
   });
@@ -210,11 +210,11 @@ function hookEvents() {
     void goToNextItem().catch(
       /** @param {unknown} error */
       (error) => {
-      reportError(error, {
-        context: 'playback',
-        fallbackMessage: 'Failed to skip to the next item.',
-        playbackStatusMessage: 'Unable to skip right now. Please try again.',
-      });
+        reportError(error, {
+          context: 'playback',
+          fallbackMessage: 'Failed to skip to the next item.',
+          playbackStatusMessage: 'Unable to skip right now. Please try again.',
+        });
       },
     );
   });
@@ -897,13 +897,14 @@ function startMonitorLoop() {
     void monitorPlayback().catch(
       /** @param {unknown} error */
       (error) => {
-      reportError(error, {
-        context: 'monitor',
-        fallbackMessage: 'Playback monitor encountered an error.',
-        playbackStatusMessage: 'Playback monitor paused due to an error. Try restarting the session.',
-        toastMode: 'cooldown',
-        toastKey: 'monitor-loop',
-      });
+        reportError(error, {
+          context: 'monitor',
+          fallbackMessage: 'Playback monitor encountered an error.',
+          playbackStatusMessage:
+            'Playback monitor paused due to an error. Try restarting the session.',
+          toastMode: 'cooldown',
+          toastKey: 'monitor-loop',
+        });
       },
     );
   }, 4000);
@@ -989,21 +990,21 @@ function restoreRuntimeState() {
   const queueItems = Array.isArray(queueValue) ? queueValue : [];
   /** @type {ShuffleItem[]} */
   const restoredQueue = queueItems.filter(
-        /**
-         * @param {unknown} item
-         * @returns {item is ShuffleItem}
-         */
-        (item) => {
-          if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
-          /** @type {Record<string, unknown>} */
-          const runtimeItem = /** @type {Record<string, unknown>} */ (item);
-          return (
-            (runtimeItem.type === 'album' || runtimeItem.type === 'playlist') &&
-            typeof runtimeItem.uri === 'string' &&
-            typeof runtimeItem.title === 'string'
-          );
-        },
+    /**
+     * @param {unknown} item
+     * @returns {item is ShuffleItem}
+     */
+    (item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+      /** @type {Record<string, unknown>} */
+      const runtimeItem = /** @type {Record<string, unknown>} */ (item);
+      return (
+        (runtimeItem.type === 'album' || runtimeItem.type === 'playlist') &&
+        typeof runtimeItem.uri === 'string' &&
+        typeof runtimeItem.title === 'string'
       );
+    },
+  );
 
   const indexValue = parsed.index;
   const restoredIndex =


### PR DESCRIPTION
### Motivation
- Remove remaining implicit `any`/untyped values so `// @ts-check` + `type-coverage` can verify the codebase at 100%.
- Make error handlers and JSON parsing flows explicitly typed to avoid false positives from the type checker.

### Description
- Add explicit `/** @param {unknown} error */` annotations for async `.catch(...)` handlers used in startup, login, playback start, import, skip and monitor loops to ensure error parameters are typed.
- Annotate intermediate variables and collections used during token refresh, item title refresh and import flows (`token`, `updated`, `response`, `entries`, `parsed`) to remove implicit `any` use without changing runtime behavior.
- Harden `getItems()` JSON parsing by treating parsed data as `unknown[]` and casting individual items to a typed shape before mapping to `ShuffleItem`.
- Normalize the runtime `queue` value into an `unknown[]` before filtering to `ShuffleItem[]` in `restoreRuntimeState()` so the restored runtime state is safely typed.

### Testing
- Ran `npx type-coverage` and confirmed type coverage reached `100.00%` (previously below target).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c586d1c7348321a4f22ca303a08343)