### PR TITLE
Split type checking into separate `tsc` and `type-coverage` GitHub Actions jobs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  typecheck:
+  tsc:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,5 +21,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run typecheck
+      - name: Run tsc
         run: npx tsc
+
+  type-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type-coverage
+        run: npx type-coverage


### PR DESCRIPTION
### Motivation
- Separate full TypeScript compilation from type coverage so each step runs and reports independently in CI.

### Description
- Rename the `typecheck` job to `tsc` and update the step name to `Run tsc` to run `npx tsc`, and add a new `type-coverage` job that installs dependencies and runs `npx type-coverage`.

### Testing
- No automated tests were executed as part of this change; the workflow now runs `tsc` and `type-coverage` jobs on CI for subsequent pushes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c59a399f28832188d21ad2c4614e8c)