### PR TITLE
Hardcode Spotify app ID in OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then open `http://localhost:4173`.
 
 1. In the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), create an app.
 2. Add your redirect URI (shown in the app UI) to the app settings.
-3. Copy the Client ID into the app.
+3. Keep using app ID `5082b1452bc24cc3a0955f2d1c4e5560` (already hardcoded in this project).
 
 ## Requested Spotify scopes (minimal)
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Then open `http://localhost:4173`.
 
 ## Spotify app setup
 
-1. In the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), create an app.
-2. Add your redirect URI (shown in the app UI) to the app settings.
-3. Keep using app ID `5082b1452bc24cc3a0955f2d1c4e5560` (already hardcoded in this project).
+No manual Spotify app setup is required for this project. The app ID is fixed to
+`5082b1452bc24cc3a0955f2d1c4e5560`, and the OAuth redirect URI is derived from the current page URL.
 
 ## Requested Spotify scopes (minimal)
 

--- a/app.js
+++ b/app.js
@@ -42,7 +42,6 @@ const el = {
   loginBtn: /** @type {HTMLButtonElement} */ (document.getElementById('login-btn')),
   logoutBtn: /** @type {HTMLButtonElement} */ (document.getElementById('logout-btn')),
   authStatus: /** @type {HTMLParagraphElement} */ (document.getElementById('auth-status')),
-  redirectUri: /** @type {HTMLElement} */ (document.getElementById('redirect-uri')),
   addForm: /** @type {HTMLFormElement} */ (document.getElementById('add-form')),
   itemUri: /** @type {HTMLInputElement} */ (document.getElementById('item-uri')),
   importPlaylistBtn: /** @type {HTMLButtonElement} */ (
@@ -95,8 +94,6 @@ bootstrap().catch(
 );
 
 async function bootstrap() {
-  el.redirectUri.textContent = location.origin + location.pathname;
-
   hookEvents();
   restoreRuntimeState();
   await handleAuthRedirect();

--- a/app.js
+++ b/app.js
@@ -26,9 +26,9 @@ const SCOPES = [
   'playlist-read-private',
   'playlist-read-collaborative',
 ];
+const SPOTIFY_APP_ID = '5082b1452bc24cc3a0955f2d1c4e5560';
 
 const STORAGE_KEYS = {
-  clientId: 'spotifyShuffler.clientId',
   verifier: 'spotifyShuffler.pkceVerifier',
   token: 'spotifyShuffler.token',
   refreshToken: 'spotifyShuffler.refreshToken',
@@ -39,7 +39,6 @@ const STORAGE_KEYS = {
 };
 
 const el = {
-  clientId: /** @type {HTMLInputElement} */ (document.getElementById('client-id')),
   loginBtn: /** @type {HTMLButtonElement} */ (document.getElementById('login-btn')),
   logoutBtn: /** @type {HTMLButtonElement} */ (document.getElementById('logout-btn')),
   authStatus: /** @type {HTMLParagraphElement} */ (document.getElementById('auth-status')),
@@ -97,7 +96,6 @@ bootstrap().catch(
 
 async function bootstrap() {
   el.redirectUri.textContent = location.origin + location.pathname;
-  el.clientId.value = localStorage.getItem(STORAGE_KEYS.clientId) ?? '';
 
   hookEvents();
   restoreRuntimeState();
@@ -375,20 +373,13 @@ function showToast(message, type = 'info', options = {}) {
 }
 
 async function startLogin() {
-  const clientId = el.clientId.value.trim();
-  if (!clientId) {
-    setAuthStatus('Please provide your Spotify Client ID.');
-    return;
-  }
-  localStorage.setItem(STORAGE_KEYS.clientId, clientId);
-
   const verifier = randomString(64);
   const challenge = await codeChallengeFromVerifier(verifier);
   localStorage.setItem(STORAGE_KEYS.verifier, verifier);
 
   const params = new URLSearchParams({
     response_type: 'code',
-    client_id: clientId,
+    client_id: SPOTIFY_APP_ID,
     scope: SCOPES.join(' '),
     redirect_uri: location.origin + location.pathname,
     code_challenge_method: 'S256',
@@ -413,11 +404,10 @@ async function handleAuthRedirect() {
 
   if (!code) return;
 
-  const clientId = localStorage.getItem(STORAGE_KEYS.clientId);
   const verifier = localStorage.getItem(STORAGE_KEYS.verifier);
 
-  if (!clientId || !verifier) {
-    setAuthStatus('Missing PKCE verifier/client ID. Try connecting again.');
+  if (!verifier) {
+    setAuthStatus('Missing PKCE verifier. Try connecting again.');
     return;
   }
 
@@ -425,7 +415,7 @@ async function handleAuthRedirect() {
     grant_type: 'authorization_code',
     code,
     redirect_uri: location.origin + location.pathname,
-    client_id: clientId,
+    client_id: SPOTIFY_APP_ID,
     code_verifier: verifier,
   });
 
@@ -463,14 +453,13 @@ function clearAuth() {
 }
 
 async function refreshSpotifyAccessToken() {
-  const clientId = localStorage.getItem(STORAGE_KEYS.clientId);
   const refreshToken = localStorage.getItem(STORAGE_KEYS.refreshToken);
-  if (!clientId || !refreshToken) return null;
+  if (!refreshToken) return null;
 
   const formData = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
-    client_id: clientId,
+    client_id: SPOTIFY_APP_ID,
   });
 
   /** @type {Response} */
@@ -550,7 +539,6 @@ function importLocalStorageJson() {
   }
 
   stopSession('Local storage imported. Session reset.');
-  el.clientId.value = localStorage.getItem(STORAGE_KEYS.clientId) ?? '';
   renderItemList();
   refreshAuthStatus();
   showToast(`Imported ${entries.length} local storage key(s).`, 'success');

--- a/index.html
+++ b/index.html
@@ -16,13 +16,6 @@
 
       <section class="panel">
         <h2>1) Connect Spotify</h2>
-        <p class="small">
-          This app uses Spotify app ID <code>5082b1452bc24cc3a0955f2d1c4e5560</code>.
-        </p>
-        <p class="small">
-          Redirect URI used for OAuth:
-          <code id="redirect-uri"></code>
-        </p>
         <div class="row">
           <button id="login-btn">Connect</button>
           <button id="logout-btn" class="secondary">Disconnect</button>

--- a/index.html
+++ b/index.html
@@ -16,10 +16,9 @@
 
       <section class="panel">
         <h2>1) Connect Spotify</h2>
-        <label>
-          Spotify Client ID
-          <input id="client-id" placeholder="Your Spotify app client ID" />
-        </label>
+        <p class="small">
+          This app uses Spotify app ID <code>5082b1452bc24cc3a0955f2d1c4e5560</code>.
+        </p>
         <p class="small">
           In your Spotify app settings, add this redirect URI:
           <code id="redirect-uri"></code>
@@ -75,7 +74,7 @@
           <textarea
             id="storage-json"
             rows="10"
-            placeholder='{"spotifyShuffler.clientId":"...","spotifyShuffler.items":"[...]"}'
+            placeholder='{"spotifyShuffler.items":"[...]"}'
           ></textarea>
         </label>
         <p class="small">

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
           This app uses Spotify app ID <code>5082b1452bc24cc3a0955f2d1c4e5560</code>.
         </p>
         <p class="small">
-          In your Spotify app settings, add this redirect URI:
+          Redirect URI used for OAuth:
           <code id="redirect-uri"></code>
         </p>
         <div class="row">


### PR DESCRIPTION
### Motivation
- Remove the runtime requirement for the user to provide a Spotify Client ID and ensure the app always uses a specific Spotify application for OAuth flows by hardcoding the app ID.

### Description
- Introduce `SPOTIFY_APP_ID = '5082b1452bc24cc3a0955f2d1c4e5560'` and use it for the OAuth authorize request, token exchange, and token refresh flows instead of reading a client ID from storage or the UI (`app.js`).
- Remove the `client-id` input from the UI and replace it with explanatory text that shows the fixed app ID (`index.html`).
- Stop storing/reading `spotifyShuffler.clientId` from `localStorage` and update local storage import placeholder to no longer reference `spotifyShuffler.clientId` (`app.js` and `index.html`).
- Update README to state that the hardcoded app ID is used for the project (`README.md`).

### Testing
- Ran `npm install --silent` which completed successfully.
- Ran `npx tsc --noEmit` which completed successfully (TypeScript check passed; npm emitted a non-fatal env warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5a4b0c9708321a80b205870615da8)