### PR TITLE
Add npm `typecheck` script to run `tsc` and `type-coverage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "detail": true,
     "strict": true,
     "showRelativePath": true
+  },
+  "scripts": {
+    "typecheck": "sh -c 'tsc; tsc_status=$?; type-coverage; tc_status=$?; [ $tsc_status -eq 0 ] && [ $tc_status -eq 0 ]'"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a single npm script to run both `tsc` and `type-coverage` so type checks and coverage checks are always executed and the overall step fails if either check fails.

### Description
- Add a `typecheck` script in `package.json` that runs `tsc` then `type-coverage`, captures both exit codes, always runs both commands, and returns a non-zero exit code if either command fails.

### Testing
- Ran `npm run typecheck` which executed both `tsc` and `type-coverage` and completed successfully (type-coverage reported `100.00%`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5aafdaaf88321bc7b4fdf56cbfb76)