### PR TITLE
Remove explicit branch glob from typecheck workflow trigger

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,8 +2,6 @@ name: Typecheck
 
 on:
   push:
-    branches:
-      - '**'
 
 jobs:
   tsc:


### PR DESCRIPTION
### Motivation
- Remove a redundant `branches: ['**']` specification from the `on.push` trigger in `./.github/workflows/typecheck.yml` so the workflow relies on GitHub Actions' default push behavior while keeping the original intent of running type checks on pushes.

### Description
- Deleted the explicit `branches:`/`- '**'` lines from `./.github/workflows/typecheck.yml`, leaving `on: push:` as the trigger and preserving the existing `tsc` and `type-coverage` job definitions.

### Testing
- Ran `npm run typecheck` which executes `tsc` and `type-coverage`, and the command completed successfully (type-coverage reported 100%).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5d8a3e1cc8321892aa20d426559b0)