### PR TITLE
ci: update typecheck workflow actions to v5

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 


### PR DESCRIPTION
### Motivation
- Replace deprecated Node.js 20 action runtimes to avoid upcoming deprecation warnings and ensure the workflow actions are compatible with Node.js 24 runtime changes.

### Description
- Updated `.github/workflows/typecheck.yml` to use `actions/checkout@v5` and `actions/setup-node@v5` in both jobs while keeping the workflow `node-version: 20`.

### Testing
- Ran `npm run typecheck`, which executed `tsc` and `type-coverage` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5db1192988321a8dff3312fb6f3aa)