### PR TITLE
ci: upgrade checkout/setup-node workflows to v5

### DIFF
--- a/.github/workflows/codex-coauthor-check.yml
+++ b/.github/workflows/codex-coauthor-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 


### PR DESCRIPTION
### Motivation
- Replace deprecated Node.js 20 JavaScript-action usage in workflows to avoid upcoming runtime breakage and follow GitHub's guidance to use action major versions that support newer Node.js runtimes.

### Description
- Updated `.github/workflows/codex-coauthor-check.yml` to use `actions/checkout@v5` and updated `.github/workflows/typecheck.yml` to use `actions/checkout@v5` and `actions/setup-node@v5` in both jobs, keeping the configured `node-version: 20` for now.

### Testing
- Ran `npm run typecheck`, which completed successfully (including `type-coverage` reporting 100% and no type errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5df05da7c83218531f12838ceaee5)