### PR TITLE
Switch to Node ESM and ESNext TypeScript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shuffle-by-album",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "type-coverage": "^2.29.7",
     "typescript": "^6.0.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM"],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext", "DOM"],
     "checkJs": true,
     "allowJs": true,
     "noEmit": true,


### PR DESCRIPTION
### Motivation
- Align the project with Node ESM and modern JavaScript features so TypeScript emits and module resolution match runtime expectations. 

### Description
- Add `"type": "module"` to `package.json` to enable Node ESM semantics.
- Update `tsconfig.json` to use `"target": "ESNext"`, `"module": "NodeNext"`, `"moduleResolution": "NodeNext"`, and `"lib": ["ESNext","DOM"]` to match the ESM and modern runtime settings.
- Preserve existing compiler options `checkJs`, `allowJs`, `noEmit`, and `strict`, and retain the `include` pattern.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c5e539fb848321ad2806151d3f9043)