### PR TITLE
Consolidate `typecheck` script and tidy package.json ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "typecheck": "sh -c 'tsc; tsc_status=$?; type-coverage; tc_status=$?; [ $tsc_status -eq 0 ] && [ $tc_status -eq 0 ]'"
+  },
   "devDependencies": {
     "type-coverage": "^2.29.7",
     "typescript": "^6.0.2"
@@ -12,8 +15,5 @@
     "detail": true,
     "strict": true,
     "showRelativePath": true
-  },
-  "scripts": {
-    "typecheck": "sh -c 'tsc; tsc_status=$?; type-coverage; tc_status=$?; [ $tsc_status -eq 0 ] && [ $tc_status -eq 0 ]'"
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the `typecheck` script is defined in `package.json` without duplicate keys and keep the package metadata organized while enforcing 100% type coverage via `type-coverage`.

### Description
- Move the `scripts` block (containing the `typecheck` command `sh -c 'tsc; tsc_status=$?; type-coverage; tc_status=$?; [ $tsc_status -eq 0 ] && [ $tc_status -eq 0 ]'`) earlier in `package.json` and remove the duplicated `scripts` entry while preserving `devDependencies` and the `typeCoverage` config.

### Testing
- Ran `npm run typecheck`, which executes `tsc` followed by `type-coverage`, and both steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c609838e008321804d35cbe8255016)