### PR TITLE
Extract typecheck logic to executable script and update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "sh -c 'tsc; tsc_status=$?; type-coverage; tc_status=$?; [ $tsc_status -eq 0 ] && [ $tc_status -eq 0 ]'"
+    "typecheck": "scripts/typecheck"
   },
   "devDependencies": {
     "type-coverage": "^2.29.7",

--- a/scripts/typecheck
+++ b/scripts/typecheck
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tsc_status=0
+npx tsc || tsc_status=$?
+
+tc_status=0
+tc_output=$(npx type-coverage 2>&1) || tc_status=$?
+
+if [ "$tc_status" -ne 0 ]; then
+  printf '%s\n' "$tc_output"
+fi
+
+[ "$tsc_status" -eq 0 ] && [ "$tc_status" -eq 0 ]


### PR DESCRIPTION
### Motivation
- Move a long inline shell in `package.json` into a dedicated script to improve readability and maintainability.
- Provide stricter error handling and clearer output when running both `tsc` and `type-coverage`.

### Description
- Add an executable `scripts/typecheck` bash wrapper that runs `npx tsc` and `npx type-coverage` while capturing their exit codes and preserving output.
- The wrapper uses `#!/usr/bin/env bash` and `set -euo pipefail` to improve robustness and prints `type-coverage` output if it fails.
- Update `package.json` to replace the inline shell command with the new script by setting the `typecheck` script to `scripts/typecheck`.
- Ensure the new script is added with executable file mode so it can be invoked directly by `npm run typecheck`.

### Testing
- Ran `npm run typecheck` which invoked the new `scripts/typecheck` wrapper and succeeded with both `tsc` and `type-coverage` returning zero exit codes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c60dc92d688321bc9bf5bb1294ebf4)