### PR TITLE
Update localStorage key prefix to shuffle-by-album

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,13 +27,13 @@ const SCOPES = [
 const SPOTIFY_APP_ID = '5082b1452bc24cc3a0955f2d1c4e5560';
 
 const STORAGE_KEYS = {
-  verifier: 'spotifyShuffler.pkceVerifier',
-  token: 'spotifyShuffler.token',
-  refreshToken: 'spotifyShuffler.refreshToken',
-  tokenExpiry: 'spotifyShuffler.tokenExpiry',
-  tokenScope: 'spotifyShuffler.tokenScope',
-  items: 'spotifyShuffler.items',
-  runtime: 'spotifyShuffler.runtime',
+  verifier: 'shuffle-by-album.pkceVerifier',
+  token: 'shuffle-by-album.token',
+  refreshToken: 'shuffle-by-album.refreshToken',
+  tokenExpiry: 'shuffle-by-album.tokenExpiry',
+  tokenScope: 'shuffle-by-album.tokenScope',
+  items: 'shuffle-by-album.items',
+  runtime: 'shuffle-by-album.runtime',
 };
 
 const el = {

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
           <textarea
             id="storage-json"
             rows="10"
-            placeholder='{"spotifyShuffler.items":"[...]"}'
+            placeholder='{"shuffle-by-album.items":"[...]"}'
           ></textarea>
         </label>
         <p class="small">


### PR DESCRIPTION
### Motivation
- Rename the app's persisted keys to use the `shuffle-by-album.` prefix to match the project identity and intentionally avoid adding any migration or fallback logic for legacy keys.

### Description
- Replace all `spotifyShuffler.` localStorage key names in `STORAGE_KEYS` with the `shuffle-by-album.` prefix in `app.js` and update the import/export placeholder in `index.html` to `{"shuffle-by-album.items":"[...]"}`.

### Testing
- Ran `npm run check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d41c70ac2883219377210aa34bdafe)