### PR TITLE
Add GitHub Action to force-push HEAD to test on push or dispatch

### DIFF
--- a/.github/workflows/force-push-test.yml
+++ b/.github/workflows/force-push-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/force-push-test.yml
+++ b/.github/workflows/force-push-test.yml
@@ -1,0 +1,22 @@
+name: Force Push to test
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  force-push-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Force push current revision to test
+        run: git push --force origin HEAD:test

--- a/.github/workflows/force-push-test.yml
+++ b/.github/workflows/force-push-test.yml
@@ -1,4 +1,4 @@
-name: Force Push to test
+name: Force Push to `test`
 
 on:
   push:
@@ -18,5 +18,5 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Force push current revision to test
+      - name: Force push current revision to `test`
         run: git push --force origin HEAD:test


### PR DESCRIPTION
### Motivation
- Ensure the current branch revision is propagated to the `test` branch automatically on any branch push or via manual dispatch for CI or preview purposes.

### Description
- Add a new workflow at `.github/workflows/force-push-test.yml` that triggers on every branch `push` and on `workflow_dispatch`.
- Grant `contents: write` permission so the workflow can push back to the repository.
- Check out the full repository history with `actions/checkout@v4` and `fetch-depth: 0` to preserve refs and allow `git push --force origin HEAD:test`.
- Run a single step that force-pushes the current `HEAD` to the remote `test` branch with `git push --force origin HEAD:test`.

### Testing
- Ran `npm run check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d41e69726c8321a77d3ebe6eb23689)