### PR TITLE
Export/import saved items as structured JSON and update UI labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -487,17 +487,24 @@ async function refreshSpotifyAccessToken() {
 }
 
 function exportLocalStorageJson() {
-  /** @type {Record<string, string>} */
+  const rawItems = localStorage.getItem(STORAGE_KEYS.items);
+  /** @type {Record<string, unknown>} */
   const data = {};
-  for (let index = 0; index < localStorage.length; index += 1) {
-    const key = localStorage.key(index);
-    if (!key) continue;
-    const value = localStorage.getItem(key);
-    data[key] = value ?? '';
+
+  if (rawItems) {
+    try {
+      data[STORAGE_KEYS.items] = JSON.parse(rawItems);
+    } catch {
+      el.storageJson.value = '';
+      showToast('Unable to export saved items because stored data is invalid JSON.', 'error');
+      return;
+    }
+  } else {
+    data[STORAGE_KEYS.items] = [];
   }
 
   el.storageJson.value = JSON.stringify(data, null, 2);
-  showToast(`Exported ${Object.keys(data).length} local storage key(s) to JSON.`, 'success');
+  showToast('Exported saved items to JSON.', 'success');
 }
 
 function importLocalStorageJson() {
@@ -521,18 +528,44 @@ function importLocalStorageJson() {
     return;
   }
 
-  /** @type {[string, unknown][]} */
-  const entries = Object.entries(parsed);
-  localStorage.clear();
-  for (const [key, value] of entries) {
-    if (typeof key !== 'string' || key.length === 0) continue;
-    localStorage.setItem(key, String(value ?? ''));
+  const parsedObject = /** @type {Record<string, unknown>} */ (parsed);
+  const maybeItems = parsedObject[STORAGE_KEYS.items];
+  if (!Array.isArray(maybeItems)) {
+    showToast('Import JSON must include a valid shuffle-by-album.items array.', 'error');
+    return;
   }
 
-  stopSession('Local storage imported. Session reset.');
+  /** @type {unknown[]} */
+  const parsedItems = maybeItems;
+
+  saveItems(
+    parsedItems
+      .filter(
+        /**
+         * @param {unknown} item
+         * @returns {item is {type: ItemType; uri: string; title?: unknown}}
+         */
+        (item) => {
+          if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+          /** @type {Record<string, unknown>} */
+          const parsedItem = /** @type {Record<string, unknown>} */ (item);
+          return (
+            (parsedItem.type === 'album' || parsedItem.type === 'playlist')
+            && typeof parsedItem.uri === 'string'
+          );
+        },
+      )
+      .map((item) => ({
+        type: item.type,
+        uri: item.uri,
+        title: typeof item.title === 'string' ? item.title : item.uri,
+      })),
+  );
+
+  stopSession('Data imported. Session reset.');
   renderItemList();
   refreshAuthStatus();
-  showToast(`Imported ${entries.length} local storage key(s).`, 'success');
+  showToast('Imported saved items.', 'success');
 }
 
 function getToken() {

--- a/index.html
+++ b/index.html
@@ -56,24 +56,24 @@
       </section>
 
       <section class="panel">
-        <h2>4) Import / Export Local Storage</h2>
+        <h2>4) Import / Export Data</h2>
         <div class="row">
-          <button id="export-storage-btn" type="button">Export Local Storage JSON</button>
+          <button id="export-storage-btn" type="button">Export Data JSON</button>
           <button id="import-storage-btn" type="button" class="secondary">
-            Import Local Storage JSON
+            Import Data JSON
           </button>
         </div>
         <label>
-          Local Storage JSON
+          Data JSON
           <textarea
             id="storage-json"
             rows="10"
-            placeholder='{"shuffle-by-album.items":"[...]"}'
+            placeholder='{"shuffle-by-album.items":[{"type":"album","uri":...'
           ></textarea>
         </label>
         <p class="small">
-          Export copies all current local storage key/value pairs into the box. Import replaces all
-          existing local storage data with the JSON object you provide.
+          Export copies your saved items into the text box.  Import replaces saved items with the
+          data in the text box.
         </p>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Simplify export/import to operate on the app's saved items model instead of dumping and replacing all browser localStorage keys.
- Add validation and normalization for imported items to prevent corrupt data from breaking the app.

### Description
- Change `exportLocalStorageJson` to serialize only `STORAGE_KEYS.items` as JSON and show a clearer success message, returning early with an error toast when stored data is invalid JSON.
- Update `importLocalStorageJson` to require an object containing `STORAGE_KEYS.items` as an array, validate each item to be an `album` or `playlist` with a `uri`, normalize `title` (fallback to `uri`), save via `saveItems`, and then call `stopSession`, `renderItemList`, and `refreshAuthStatus`.
- Update UI copy in `index.html` to reflect the new behavior by renaming section and buttons to "Data" instead of "Local Storage", updating the textarea placeholder, and clarifying the export/import description.

### Testing
- No automated tests were added or run as part of this change.
- Manual checks performed by exercising the export and import flows in the UI (export shows saved items JSON, importing validated data updates the list and resets the session) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d421ecd7648321a5c5c687d0e37bd0)