### PR TITLE
Extract Spotify API client into dedicated module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import { configureSpotifyApi, spotifyApi, SpotifyApiHttpError } from './spotify-api.js';
+import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -81,7 +81,7 @@ const errorToastLastShownAt = new Map();
 
 /** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
 
-configureSpotifyApi({
+const spotifyApi = new SpotifyApi({
   refreshSpotifyAccessToken,
   clearAuth,
   transitionToDetached,
@@ -785,7 +785,7 @@ async function reattachSession() {
     return;
   }
 
-  const response = await spotifyApi('/me/player', { method: 'GET' }, token, false);
+  const response = await spotifyApi.request('/me/player', { method: 'GET' }, token, false);
   if (!response.ok && response.status !== 204) {
     if (isUnrecoverableSpotifyStatus(response.status)) {
       transitionToDetached(spotifyStatusMessage(response.status, 'Unable to reattach playback state.'));
@@ -838,10 +838,10 @@ async function playCurrentItem() {
   }
 
   try {
-    await spotifyApi('/me/player/shuffle?state=false', { method: 'PUT' }, token);
-    await spotifyApi('/me/player/repeat?state=off', { method: 'PUT' }, token);
+    await spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' }, token);
+    await spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' }, token);
 
-    await spotifyApi(
+    await spotifyApi.request(
       '/me/player/play',
       {
         method: 'PUT',
@@ -928,7 +928,7 @@ async function fetchPlaylistAlbums(playlistId, token) {
       additional_types: 'track',
       market: 'from_token',
     });
-    const response = await spotifyApi(
+    const response = await spotifyApi.request(
       `/playlists/${playlistId}/items?${params.toString()}`,
       { method: 'GET' },
       token,
@@ -976,7 +976,7 @@ async function withItemTitle(item, token) {
   if (!id) return null;
 
   const path = item.type === 'album' ? `/albums/${id}` : `/playlists/${id}`;
-  const response = await spotifyApi(path, { method: 'GET' }, token, false);
+  const response = await spotifyApi.request(path, { method: 'GET' }, token, false);
   if (!response.ok) return null;
 
   /** @type {{name?: string}} */
@@ -1014,7 +1014,7 @@ async function monitorPlayback() {
     return;
   }
 
-  const response = await spotifyApi('/me/player', { method: 'GET' }, token, false);
+  const response = await spotifyApi.request('/me/player', { method: 'GET' }, token, false);
   if (response.status === 204) {
     // nothing currently playing/active
     return;

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+import { configureSpotifyApi, spotifyApi, SpotifyApiHttpError } from './spotify-api.js';
+
 /** @typedef {'album' | 'playlist'} ItemType */
 
 /**
@@ -77,24 +79,15 @@ const ERROR_TOAST_COOLDOWN_MS = 45000;
 /** @type {Map<string, number>} */
 const errorToastLastShownAt = new Map();
 
-class SpotifyApiHttpError extends Error {
-  /** @type {string} */
-  name;
-  /** @type {number} */
-  status;
-
-  /**
-   * @param {number} status
-   * @param {string} message
-   */
-  constructor(status, message) {
-    super(message);
-    this.name = 'SpotifyApiHttpError';
-    this.status = status;
-  }
-}
-
 /** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
+
+configureSpotifyApi({
+  refreshSpotifyAccessToken,
+  clearAuth,
+  transitionToDetached,
+  setAuthStatus,
+  spotifyStatusMessage,
+});
 
 void runWithReportedError(bootstrap, {
   context: 'startup',
@@ -1205,46 +1198,6 @@ function renderSessionQueue() {
  */
 function formatNowPlayingStatus(item) {
   return `Now playing ${item.type} ${session.index + 1} of ${session.queue.length}: ${item.title}`;
-}
-
-/**
- * @param {string} path
- * @param {RequestInit} init
- * @param {string} token
- * @param {boolean} throwOnError
- */
-async function spotifyApi(path, init, token, throwOnError = true) {
-  /** @param {string} bearerToken */
-  const makeRequest = (bearerToken) =>
-    fetch(`https://api.spotify.com/v1${path}`, {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${bearerToken}`,
-        'Content-Type': 'application/json',
-        ...(init.headers ?? {}),
-      },
-    });
-
-  let response = await makeRequest(token);
-  if (response.status === 401) {
-    const refreshedToken = await refreshSpotifyAccessToken();
-    if (refreshedToken) {
-      response = await makeRequest(refreshedToken);
-    }
-
-    if (response.status === 401) {
-      clearAuth();
-      transitionToDetached('Spotify session expired. Please reconnect.');
-      setAuthStatus('Spotify session expired. Please reconnect.');
-    }
-  }
-
-  if (!response.ok && throwOnError) {
-    const body = await response.text();
-    const message = spotifyStatusMessage(response.status, `Spotify API request failed for ${path}.`);
-    throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
-  }
-  return response;
 }
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -82,6 +82,7 @@ const errorToastLastShownAt = new Map();
 /** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
 
 const spotifyApi = new SpotifyApi({
+  getAccessToken: getUsableAccessToken,
   refreshSpotifyAccessToken,
   clearAuth,
   transitionToDetached,
@@ -155,7 +156,7 @@ function hookEvents() {
         return;
       }
 
-      const titledItem = await withItemTitle(parsed, token);
+      const titledItem = await withItemTitle(parsed);
       if (!titledItem) {
         showToast('Unable to load title for that item. Please try another URI.', 'error');
         return;
@@ -263,7 +264,7 @@ async function ensureStoredItemTitles() {
       continue;
     }
 
-    const titledItem = await withItemTitle(item, token);
+    const titledItem = await withItemTitle(item);
     if (!titledItem) {
       updated.push({ ...item, title: item.uri });
     } else {
@@ -785,7 +786,7 @@ async function reattachSession() {
     return;
   }
 
-  const response = await spotifyApi.request('/me/player', { method: 'GET' }, token, false);
+  const response = await spotifyApi.request('/me/player', { method: 'GET' }, false);
   if (!response.ok && response.status !== 204) {
     if (isUnrecoverableSpotifyStatus(response.status)) {
       transitionToDetached(spotifyStatusMessage(response.status, 'Unable to reattach playback state.'));
@@ -838,8 +839,8 @@ async function playCurrentItem() {
   }
 
   try {
-    await spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' }, token);
-    await spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' }, token);
+    await spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' });
+    await spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' });
 
     await spotifyApi.request(
       '/me/player/play',
@@ -850,8 +851,7 @@ async function playCurrentItem() {
           offset: { position: 0 },
           position_ms: 0,
         }),
-      },
-      token,
+      }
     );
   } catch (error) {
     reportError(error, {
@@ -887,7 +887,7 @@ async function importAlbumsFromPlaylist() {
 
   const existingItems = getItems();
   const existingUris = new Set(existingItems.map((item) => item.uri));
-  const importResult = await fetchPlaylistAlbums(parsedPlaylist.id, token);
+  const importResult = await fetchPlaylistAlbums(parsedPlaylist.id);
   if (importResult.errorMessage) {
     showToast(importResult.errorMessage, 'error');
     return;
@@ -912,10 +912,9 @@ async function importAlbumsFromPlaylist() {
 
 /**
  * @param {string} playlistId
- * @param {string} token
  * @returns {Promise<{albums: ShuffleItem[]; errorMessage: string | null}>}
  */
-async function fetchPlaylistAlbums(playlistId, token) {
+async function fetchPlaylistAlbums(playlistId) {
   /** @type {Map<string, ShuffleItem>} */
   const albumsByUri = new Map();
   let offset = 0;
@@ -931,7 +930,6 @@ async function fetchPlaylistAlbums(playlistId, token) {
     const response = await spotifyApi.request(
       `/playlists/${playlistId}/items?${params.toString()}`,
       { method: 'GET' },
-      token,
       false,
     );
     if (!response.ok) {
@@ -968,15 +966,14 @@ async function fetchPlaylistAlbums(playlistId, token) {
 
 /**
  * @param {{uri: string; type: ItemType; title?: string}} item
- * @param {string} token
  * @returns {Promise<ShuffleItem | null>}
  */
-async function withItemTitle(item, token) {
+async function withItemTitle(item) {
   const id = spotifyIdFromUri(item.uri);
   if (!id) return null;
 
   const path = item.type === 'album' ? `/albums/${id}` : `/playlists/${id}`;
-  const response = await spotifyApi.request(path, { method: 'GET' }, token, false);
+  const response = await spotifyApi.request(path, { method: 'GET' }, false);
   if (!response.ok) return null;
 
   /** @type {{name?: string}} */
@@ -1014,7 +1011,7 @@ async function monitorPlayback() {
     return;
   }
 
-  const response = await spotifyApi.request('/me/player', { method: 'GET' }, token, false);
+  const response = await spotifyApi.request('/me/player', { method: 'GET' }, false);
   if (response.status === 204) {
     // nothing currently playing/active
     return;

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
+import { SpotifyAppApi } from './spotify-app-api.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -89,6 +90,7 @@ const spotifyApi = new SpotifyApi({
   setAuthStatus,
   spotifyStatusMessage,
 });
+const spotifyAppApi = new SpotifyAppApi(spotifyApi);
 
 void runWithReportedError(bootstrap, {
   context: 'startup',
@@ -786,23 +788,18 @@ async function reattachSession() {
     return;
   }
 
-  const response = await spotifyApi.request('/me/player', { method: 'GET' }, false);
-  if (!response.ok && response.status !== 204) {
-    if (isUnrecoverableSpotifyStatus(response.status)) {
-      transitionToDetached(spotifyStatusMessage(response.status, 'Unable to reattach playback state.'));
+  const playerState = await spotifyAppApi.getPlayerState();
+  if (!playerState.ok) {
+    if (isUnrecoverableSpotifyStatus(playerState.status)) {
+      transitionToDetached(spotifyStatusMessage(playerState.status, 'Unable to reattach playback state.'));
       return;
     }
-    const details = await response.text();
-    throw new Error(`Unable to check current Spotify playback (${response.status}): ${details}`);
+    throw new Error(
+      `Unable to check current Spotify playback (${playerState.status}): ${playerState.errorText}`,
+    );
   }
 
-  /** @type {string | null} */
-  let contextUri = null;
-  if (response.status !== 204) {
-    /** @type {{context?: {uri?: string} | null}} */
-    const data = await response.json();
-    contextUri = data.context?.uri ?? null;
-  }
+  const contextUri = playerState.contextUri;
 
   if (contextUri !== current.uri) {
     session.activationState = 'active';
@@ -839,20 +836,9 @@ async function playCurrentItem() {
   }
 
   try {
-    await spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' });
-    await spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' });
-
-    await spotifyApi.request(
-      '/me/player/play',
-      {
-        method: 'PUT',
-        body: JSON.stringify({
-          context_uri: current.uri,
-          offset: { position: 0 },
-          position_ms: 0,
-        }),
-      }
-    );
+    await spotifyAppApi.disableShuffle();
+    await spotifyAppApi.disableRepeat();
+    await spotifyAppApi.playContext(current.uri);
   } catch (error) {
     reportError(error, {
       context: 'playback',
@@ -921,43 +907,25 @@ async function fetchPlaylistAlbums(playlistId) {
   const limit = 50;
 
   while (true) {
-    const params = new URLSearchParams({
-      limit: String(limit),
-      offset: String(offset),
-      additional_types: 'track',
-      market: 'from_token',
-    });
-    const response = await spotifyApi.request(
-      `/playlists/${playlistId}/items?${params.toString()}`,
-      { method: 'GET' },
-      false,
-    );
-    if (!response.ok) {
-      const details = await response.text();
+    const page = await spotifyAppApi.getPlaylistAlbumsPage(playlistId, offset, limit);
+    if (!page.ok) {
       return {
         albums: [],
-        errorMessage: `Unable to import albums from that playlist (${response.status}). ${details || 'Please try again.'}`,
+        errorMessage: `Unable to import albums from that playlist (${page.status}). ${page.errorText || 'Please try again.'}`,
       };
     }
 
-    /** @type {{items?: Array<{item?: {album?: {uri?: string; id?: string; name?: string} | null} | null}>; next?: string | null}} */
-    const data = await response.json();
-    const items = data.items ?? [];
-    for (const entry of items) {
-      const album = entry?.item?.album;
-      const albumUri = album?.uri ?? (album?.id ? `spotify:album:${album.id}` : '');
-      const albumName = (album?.name ?? '').trim();
-      if (!albumUri) continue;
-      if (!albumsByUri.has(albumUri)) {
-        albumsByUri.set(albumUri, {
-          uri: albumUri,
+    for (const album of page.albums) {
+      if (!albumsByUri.has(album.uri)) {
+        albumsByUri.set(album.uri, {
+          uri: album.uri,
           type: 'album',
-          title: albumName || albumUri,
+          title: album.title || album.uri,
         });
       }
     }
 
-    if (!data.next) break;
+    if (!page.hasNext) break;
     offset += limit;
   }
 
@@ -972,13 +940,7 @@ async function withItemTitle(item) {
   const id = spotifyIdFromUri(item.uri);
   if (!id) return null;
 
-  const path = item.type === 'album' ? `/albums/${id}` : `/playlists/${id}`;
-  const response = await spotifyApi.request(path, { method: 'GET' }, false);
-  if (!response.ok) return null;
-
-  /** @type {{name?: string}} */
-  const data = await response.json();
-  const title = (data.name ?? '').trim();
+  const title = await spotifyAppApi.getItemTitle(item.type, id);
   if (!title) return null;
 
   return { uri: item.uri, type: item.type, title };
@@ -1011,43 +973,23 @@ async function monitorPlayback() {
     return;
   }
 
-  const response = await spotifyApi.request('/me/player', { method: 'GET' }, false);
-  if (response.status === 204) {
-    // nothing currently playing/active
-    return;
-  }
-
-  if (!response.ok) {
-    if (isUnrecoverableSpotifyStatus(response.status)) {
-      transitionToDetached(spotifyStatusMessage(response.status, 'Spotify playback monitor detached.'));
+  const playerState = await spotifyAppApi.getPlayerState();
+  if (!playerState.ok) {
+    if (isUnrecoverableSpotifyStatus(playerState.status)) {
+      transitionToDetached(spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'));
       return;
     }
-    const details = await response.text();
-    reportError(new Error(`Playback monitor request failed (${response.status}): ${details}`), {
+    reportError(new Error(`Playback monitor request failed (${playerState.status}): ${playerState.errorText}`), {
       context: 'monitor',
-      fallbackMessage: spotifyStatusMessage(response.status, 'Could not check playback state.'),
+      fallbackMessage: spotifyStatusMessage(playerState.status, 'Could not check playback state.'),
       playbackStatusMessage: 'Unable to check playback state right now.',
       toastMode: 'cooldown',
-      toastKey: `monitor-http-${response.status}`,
+      toastKey: `monitor-http-${playerState.status}`,
     });
     return;
   }
 
-  const data = await runWithReportedError(
-    async () =>
-      /** @type {{context?: {uri?: string} | null}} */ (await response.json()),
-    {
-      context: 'monitor',
-      fallbackMessage: 'Unexpected playback response from Spotify.',
-      playbackStatusMessage: 'Unable to read current playback state.',
-      toastMode: 'cooldown',
-      toastKey: 'monitor-json',
-    },
-  );
-  if (!data) {
-    return;
-  }
-  const contextUri = data.context?.uri ?? null;
+  const contextUri = playerState.contextUri;
 
   if (contextUri === session.currentUri) {
     session.observedCurrentContext = true;

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
 import { SpotifyAppApi } from './spotify-app-api.js';
+import { spotifyStatusMessage } from './spotify-status-message.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -86,7 +87,6 @@ const spotifyApi = new SpotifyApi({
   getAccessToken: getUsableAccessToken,
   refreshSpotifyAccessToken,
   handleAuthExpired,
-  spotifyStatusMessage,
 });
 const spotifyAppApi = new SpotifyAppApi(spotifyApi);
 
@@ -1204,29 +1204,6 @@ function errorMessageForUser(error, fallbackMessage) {
   const raw = error instanceof Error ? error.message : String(error ?? '');
   if (raw && (/Failed to fetch/i.test(raw) || /NetworkError/i.test(raw))) {
     return 'Network error while contacting Spotify. Please try again.';
-  }
-  return fallbackMessage;
-}
-
-/**
- * @param {number} status
- * @param {string} fallbackMessage
- */
-function spotifyStatusMessage(status, fallbackMessage) {
-  if (status === 401) {
-    return 'Spotify session expired. Please reconnect.';
-  }
-  if (status === 403) {
-    return 'Spotify permissions are missing. Disconnect and reconnect.';
-  }
-  if (status === 404) {
-    return 'Requested Spotify item or playback device was not found.';
-  }
-  if (status === 429) {
-    return 'Spotify rate limit reached. Please wait a moment and retry.';
-  }
-  if (status >= 500) {
-    return 'Spotify is temporarily unavailable. Please try again shortly.';
   }
   return fallbackMessage;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1223,9 +1223,7 @@ function isUnrecoverableSpotifyError(error) {
  */
 function spotifyStatusFromError(error) {
   if (error instanceof SpotifyApiHttpError) return error.status;
-  if (!(error instanceof Error)) return null;
-  const legacyStatus = /** @type {Error & {spotifyStatus?: unknown}} */ (error).spotifyStatus;
-  return typeof legacyStatus === 'number' ? legacyStatus : null;
+  return null;
 }
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -85,9 +85,7 @@ const errorToastLastShownAt = new Map();
 const spotifyApi = new SpotifyApi({
   getAccessToken: getUsableAccessToken,
   refreshSpotifyAccessToken,
-  clearAuth,
-  transitionToDetached,
-  setAuthStatus,
+  handleAuthExpired,
   spotifyStatusMessage,
 });
 const spotifyAppApi = new SpotifyAppApi(spotifyApi);
@@ -279,6 +277,12 @@ async function ensureStoredItemTitles() {
     saveItems(updated);
     renderItemList();
   }
+}
+
+function handleAuthExpired() {
+  clearAuth();
+  transitionToDetached('Spotify session expired. Please reconnect.');
+  setAuthStatus('Spotify session expired. Please reconnect.');
 }
 
 /** @param {string} message */

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -1,3 +1,5 @@
+import { spotifyStatusMessage } from './spotify-status-message.js';
+
 export class SpotifyApiHttpError extends Error {
   /** @type {string} */
   name;
@@ -20,7 +22,6 @@ export class SpotifyApiHttpError extends Error {
  * getAccessToken?: () => Promise<string | null>;
  * refreshSpotifyAccessToken?: () => Promise<string | null>;
  * handleAuthExpired?: () => void;
- * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
  * }} SpotifyApiDeps
  */
 
@@ -43,9 +44,7 @@ export class SpotifyApi {
   async request(path, init, throwOnError = true) {
     /** @param {number} status */
     const statusMessage = (status) =>
-      this.deps.spotifyStatusMessage
-        ? this.deps.spotifyStatusMessage(status, `Spotify API request failed for ${path}.`)
-        : `Spotify API request failed for ${path}.`;
+      spotifyStatusMessage(status, `Spotify API request failed for ${path}.`);
 
     /** @param {string} bearerToken */
     const makeRequest = (bearerToken) =>

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -19,9 +19,9 @@ export class SpotifyApiHttpError extends Error {
 
 /**
  * @typedef {{
- * getAccessToken?: () => Promise<string | null>;
- * refreshSpotifyAccessToken?: () => Promise<string | null>;
- * handleAuthExpired?: () => void;
+ * getAccessToken: () => Promise<string | null>;
+ * refreshSpotifyAccessToken: () => Promise<string | null>;
+ * handleAuthExpired: () => void;
  * }} SpotifyApiDeps
  */
 
@@ -57,21 +57,21 @@ export class SpotifyApi {
         },
       });
 
-    const token = await this.deps.getAccessToken?.();
+    const token = await this.deps.getAccessToken();
     if (!token) {
-      this.deps.handleAuthExpired?.();
+      this.deps.handleAuthExpired();
       throw new SpotifyApiHttpError(401, statusMessage(401));
     }
 
     let response = await makeRequest(token);
     if (response.status === 401) {
-      const refreshedToken = await this.deps.refreshSpotifyAccessToken?.();
+      const refreshedToken = await this.deps.refreshSpotifyAccessToken();
       if (refreshedToken) {
         response = await makeRequest(refreshedToken);
       }
 
       if (response.status === 401) {
-        this.deps.handleAuthExpired?.();
+        this.deps.handleAuthExpired();
       }
     }
 

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -42,10 +42,6 @@ export class SpotifyApi {
    * @param {boolean} throwOnError
    */
   async request(path, init, throwOnError = true) {
-    /** @param {number} status */
-    const statusMessage = (status) =>
-      spotifyStatusMessage(status, `Spotify API request failed for ${path}.`);
-
     /** @param {string} bearerToken */
     const makeRequest = (bearerToken) =>
       fetch(`https://api.spotify.com/v1${path}`, {
@@ -60,7 +56,7 @@ export class SpotifyApi {
     const token = await this.deps.getAccessToken();
     if (!token) {
       this.deps.handleAuthExpired();
-      throw new SpotifyApiHttpError(401, statusMessage(401));
+      throw new SpotifyApiHttpError(401, spotifyStatusMessage(401, `Spotify API request failed for ${path}.`));
     }
 
     let response = await makeRequest(token);
@@ -77,7 +73,7 @@ export class SpotifyApi {
 
     if (!response.ok && throwOnError) {
       const body = await response.text();
-      const message = statusMessage(response.status);
+      const message = spotifyStatusMessage(response.status, `Spotify API request failed for ${path}.`);
       throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
     }
 

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -38,18 +38,18 @@ export class SpotifyApi {
 
   /**
    * @param {string} path
-   * @param {RequestInit} init
+   * @param {RequestInit} requestInit
    * @param {boolean} throwOnError
    */
-  async request(path, init, throwOnError = true) {
+  async request(path, requestInit, throwOnError = true) {
     /** @param {string} bearerToken */
     const makeRequest = (bearerToken) =>
       fetch(`https://api.spotify.com/v1${path}`, {
-        ...init,
+        ...requestInit,
         headers: {
           Authorization: `Bearer ${bearerToken}`,
           'Content-Type': 'application/json',
-          ...(init.headers ?? {}),
+          ...(requestInit.headers ?? {}),
         },
       });
 

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -15,62 +15,70 @@ export class SpotifyApiHttpError extends Error {
   }
 }
 
-/** @type {{
- * refreshSpotifyAccessToken?: () => Promise<string | null>;
- * clearAuth?: () => void;
- * transitionToDetached?: (message: string) => void;
- * setAuthStatus?: (message: string) => void;
- * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
- * }} */
-const deps = {};
+export class SpotifyApi {
+  /** @type {{
+   * refreshSpotifyAccessToken?: () => Promise<string | null>;
+   * clearAuth?: () => void;
+   * transitionToDetached?: (message: string) => void;
+   * setAuthStatus?: (message: string) => void;
+   * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
+   * }} */
+  deps;
 
-/**
- * @param {typeof deps} nextDeps
- */
-export function configureSpotifyApi(nextDeps) {
-  Object.assign(deps, nextDeps);
-}
+  /**
+   * @param {{
+   * refreshSpotifyAccessToken?: () => Promise<string | null>;
+   * clearAuth?: () => void;
+   * transitionToDetached?: (message: string) => void;
+   * setAuthStatus?: (message: string) => void;
+   * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
+   * }} deps
+   */
+  constructor(deps) {
+    this.deps = deps;
+  }
 
-/**
- * @param {string} path
- * @param {RequestInit} init
- * @param {string} token
- * @param {boolean} throwOnError
- */
-export async function spotifyApi(path, init, token, throwOnError = true) {
-  /** @param {string} bearerToken */
-  const makeRequest = (bearerToken) =>
-    fetch(`https://api.spotify.com/v1${path}`, {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${bearerToken}`,
-        'Content-Type': 'application/json',
-        ...(init.headers ?? {}),
-      },
-    });
+  /**
+   * @param {string} path
+   * @param {RequestInit} init
+   * @param {string} token
+   * @param {boolean} throwOnError
+   */
+  async request(path, init, token, throwOnError = true) {
+    /** @param {string} bearerToken */
+    const makeRequest = (bearerToken) =>
+      fetch(`https://api.spotify.com/v1${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+          'Content-Type': 'application/json',
+          ...(init.headers ?? {}),
+        },
+      });
 
-  let response = await makeRequest(token);
-  if (response.status === 401) {
-    const refreshedToken = await deps.refreshSpotifyAccessToken?.();
-    if (refreshedToken) {
-      response = await makeRequest(refreshedToken);
-    }
-
+    let response = await makeRequest(token);
     if (response.status === 401) {
-      deps.clearAuth?.();
-      deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
-      deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+      const refreshedToken = await this.deps.refreshSpotifyAccessToken?.();
+      if (refreshedToken) {
+        response = await makeRequest(refreshedToken);
+      }
+
+      if (response.status === 401) {
+        this.deps.clearAuth?.();
+        this.deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
+        this.deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+      }
     }
-  }
 
-  if (!response.ok && throwOnError) {
-    const body = await response.text();
-    const fallbackMessage = `Spotify API request failed for ${path}.`;
-    const message = deps.spotifyStatusMessage
-      ? deps.spotifyStatusMessage(response.status, fallbackMessage)
-      : fallbackMessage;
-    throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
-  }
+    if (!response.ok && throwOnError) {
+      const body = await response.text();
+      const fallbackMessage = `Spotify API request failed for ${path}.`;
+      const message = this.deps.spotifyStatusMessage
+        ? this.deps.spotifyStatusMessage(response.status, fallbackMessage)
+        : fallbackMessage;
+      throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
+    }
 
-  return response;
+    return response;
+  }
 }

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -1,0 +1,76 @@
+export class SpotifyApiHttpError extends Error {
+  /** @type {string} */
+  name;
+  /** @type {number} */
+  status;
+
+  /**
+   * @param {number} status
+   * @param {string} message
+   */
+  constructor(status, message) {
+    super(message);
+    this.name = 'SpotifyApiHttpError';
+    this.status = status;
+  }
+}
+
+/** @type {{
+ * refreshSpotifyAccessToken?: () => Promise<string | null>;
+ * clearAuth?: () => void;
+ * transitionToDetached?: (message: string) => void;
+ * setAuthStatus?: (message: string) => void;
+ * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
+ * }} */
+const deps = {};
+
+/**
+ * @param {typeof deps} nextDeps
+ */
+export function configureSpotifyApi(nextDeps) {
+  Object.assign(deps, nextDeps);
+}
+
+/**
+ * @param {string} path
+ * @param {RequestInit} init
+ * @param {string} token
+ * @param {boolean} throwOnError
+ */
+export async function spotifyApi(path, init, token, throwOnError = true) {
+  /** @param {string} bearerToken */
+  const makeRequest = (bearerToken) =>
+    fetch(`https://api.spotify.com/v1${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {}),
+      },
+    });
+
+  let response = await makeRequest(token);
+  if (response.status === 401) {
+    const refreshedToken = await deps.refreshSpotifyAccessToken?.();
+    if (refreshedToken) {
+      response = await makeRequest(refreshedToken);
+    }
+
+    if (response.status === 401) {
+      deps.clearAuth?.();
+      deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
+      deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+    }
+  }
+
+  if (!response.ok && throwOnError) {
+    const body = await response.text();
+    const fallbackMessage = `Spotify API request failed for ${path}.`;
+    const message = deps.spotifyStatusMessage
+      ? deps.spotifyStatusMessage(response.status, fallbackMessage)
+      : fallbackMessage;
+    throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
+  }
+
+  return response;
+}

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -17,6 +17,7 @@ export class SpotifyApiHttpError extends Error {
 
 export class SpotifyApi {
   /** @type {{
+   * getAccessToken?: () => Promise<string | null>;
    * refreshSpotifyAccessToken?: () => Promise<string | null>;
    * clearAuth?: () => void;
    * transitionToDetached?: (message: string) => void;
@@ -27,6 +28,7 @@ export class SpotifyApi {
 
   /**
    * @param {{
+   * getAccessToken?: () => Promise<string | null>;
    * refreshSpotifyAccessToken?: () => Promise<string | null>;
    * clearAuth?: () => void;
    * transitionToDetached?: (message: string) => void;
@@ -41,10 +43,15 @@ export class SpotifyApi {
   /**
    * @param {string} path
    * @param {RequestInit} init
-   * @param {string} token
    * @param {boolean} throwOnError
    */
-  async request(path, init, token, throwOnError = true) {
+  async request(path, init, throwOnError = true) {
+    /** @param {number} status */
+    const statusMessage = (status) =>
+      this.deps.spotifyStatusMessage
+        ? this.deps.spotifyStatusMessage(status, `Spotify API request failed for ${path}.`)
+        : `Spotify API request failed for ${path}.`;
+
     /** @param {string} bearerToken */
     const makeRequest = (bearerToken) =>
       fetch(`https://api.spotify.com/v1${path}`, {
@@ -55,6 +62,14 @@ export class SpotifyApi {
           ...(init.headers ?? {}),
         },
       });
+
+    const token = await this.deps.getAccessToken?.();
+    if (!token) {
+      this.deps.clearAuth?.();
+      this.deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
+      this.deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+      throw new SpotifyApiHttpError(401, statusMessage(401));
+    }
 
     let response = await makeRequest(token);
     if (response.status === 401) {
@@ -72,10 +87,7 @@ export class SpotifyApi {
 
     if (!response.ok && throwOnError) {
       const body = await response.text();
-      const fallbackMessage = `Spotify API request failed for ${path}.`;
-      const message = this.deps.spotifyStatusMessage
-        ? this.deps.spotifyStatusMessage(response.status, fallbackMessage)
-        : fallbackMessage;
+      const message = statusMessage(response.status);
       throw new SpotifyApiHttpError(response.status, body ? `${message} ${body}` : message);
     }
 

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -15,26 +15,23 @@ export class SpotifyApiHttpError extends Error {
   }
 }
 
+/**
+ * @typedef {{
+ * getAccessToken?: () => Promise<string | null>;
+ * refreshSpotifyAccessToken?: () => Promise<string | null>;
+ * clearAuth?: () => void;
+ * transitionToDetached?: (message: string) => void;
+ * setAuthStatus?: (message: string) => void;
+ * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
+ * }} SpotifyApiDeps
+ */
+
 export class SpotifyApi {
-  /** @type {{
-   * getAccessToken?: () => Promise<string | null>;
-   * refreshSpotifyAccessToken?: () => Promise<string | null>;
-   * clearAuth?: () => void;
-   * transitionToDetached?: (message: string) => void;
-   * setAuthStatus?: (message: string) => void;
-   * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
-   * }} */
+  /** @type {SpotifyApiDeps} */
   deps;
 
   /**
-   * @param {{
-   * getAccessToken?: () => Promise<string | null>;
-   * refreshSpotifyAccessToken?: () => Promise<string | null>;
-   * clearAuth?: () => void;
-   * transitionToDetached?: (message: string) => void;
-   * setAuthStatus?: (message: string) => void;
-   * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
-   * }} deps
+   * @param {SpotifyApiDeps} deps
    */
   constructor(deps) {
     this.deps = deps;

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -19,9 +19,7 @@ export class SpotifyApiHttpError extends Error {
  * @typedef {{
  * getAccessToken?: () => Promise<string | null>;
  * refreshSpotifyAccessToken?: () => Promise<string | null>;
- * clearAuth?: () => void;
- * transitionToDetached?: (message: string) => void;
- * setAuthStatus?: (message: string) => void;
+ * handleAuthExpired?: () => void;
  * spotifyStatusMessage?: (status: number, fallbackMessage: string) => string;
  * }} SpotifyApiDeps
  */
@@ -62,9 +60,7 @@ export class SpotifyApi {
 
     const token = await this.deps.getAccessToken?.();
     if (!token) {
-      this.deps.clearAuth?.();
-      this.deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
-      this.deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+      this.deps.handleAuthExpired?.();
       throw new SpotifyApiHttpError(401, statusMessage(401));
     }
 
@@ -76,9 +72,7 @@ export class SpotifyApi {
       }
 
       if (response.status === 401) {
-        this.deps.clearAuth?.();
-        this.deps.transitionToDetached?.('Spotify session expired. Please reconnect.');
-        this.deps.setAuthStatus?.('Spotify session expired. Please reconnect.');
+        this.deps.handleAuthExpired?.();
       }
     }
 

--- a/src/spotify-app-api.js
+++ b/src/spotify-app-api.js
@@ -1,0 +1,154 @@
+import { SpotifyApi } from './spotify-api.js';
+
+/** @typedef {'album' | 'playlist'} ItemType */
+
+/**
+ * @typedef {{
+ *   ok: true;
+ *   status: number;
+ *   contextUri: string | null;
+ * }} PlayerStateSuccess
+ */
+
+/**
+ * @typedef {{
+ *   ok: false;
+ *   status: number;
+ *   errorText: string;
+ * }} PlayerStateFailure
+ */
+
+/** @typedef {PlayerStateSuccess | PlayerStateFailure} PlayerStateResponse */
+
+/**
+ * @typedef {{
+ *   uri: string;
+ *   title: string;
+ * }} PlaylistAlbum
+ */
+
+/**
+ * @typedef {{
+ *   ok: true;
+ *   status: number;
+ *   albums: PlaylistAlbum[];
+ *   hasNext: boolean;
+ * }} PlaylistAlbumsPageSuccess
+ */
+
+/**
+ * @typedef {{
+ *   ok: false;
+ *   status: number;
+ *   errorText: string;
+ * }} PlaylistAlbumsPageFailure
+ */
+
+/** @typedef {PlaylistAlbumsPageSuccess | PlaylistAlbumsPageFailure} PlaylistAlbumsPageResponse */
+
+export class SpotifyAppApi {
+  /** @type {SpotifyApi} */
+  spotifyApi;
+
+  /** @param {SpotifyApi} spotifyApi */
+  constructor(spotifyApi) {
+    this.spotifyApi = spotifyApi;
+  }
+
+  /** @returns {Promise<PlayerStateResponse>} */
+  async getPlayerState() {
+    const response = await this.spotifyApi.request('/me/player', { method: 'GET' }, false);
+    if (response.status === 204) {
+      return { ok: true, status: response.status, contextUri: null };
+    }
+    if (!response.ok) {
+      return { ok: false, status: response.status, errorText: await response.text() };
+    }
+
+    /** @type {{context?: {uri?: string} | null}} */
+    const data = await response.json();
+    return { ok: true, status: response.status, contextUri: data.context?.uri ?? null };
+  }
+
+  /** @returns {Promise<void>} */
+  async disableShuffle() {
+    await this.spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' });
+  }
+
+  /** @returns {Promise<void>} */
+  async disableRepeat() {
+    await this.spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' });
+  }
+
+  /** @param {string} contextUri */
+  async playContext(contextUri) {
+    await this.spotifyApi.request('/me/player/play', {
+      method: 'PUT',
+      body: JSON.stringify({
+        context_uri: contextUri,
+        offset: { position: 0 },
+        position_ms: 0,
+      }),
+    });
+  }
+
+  /**
+   * @param {string} playlistId
+   * @param {number} offset
+   * @param {number} limit
+   * @returns {Promise<PlaylistAlbumsPageResponse>}
+   */
+  async getPlaylistAlbumsPage(playlistId, offset, limit) {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      additional_types: 'track',
+      market: 'from_token',
+    });
+
+    const response = await this.spotifyApi.request(
+      `/playlists/${playlistId}/items?${params.toString()}`,
+      { method: 'GET' },
+      false,
+    );
+
+    if (!response.ok) {
+      return { ok: false, status: response.status, errorText: await response.text() };
+    }
+
+    /** @type {{items?: Array<{item?: {album?: {uri?: string; id?: string; name?: string} | null} | null}>; next?: string | null}} */
+    const data = await response.json();
+
+    /** @type {PlaylistAlbum[]} */
+    const albums = [];
+    for (const entry of data.items ?? []) {
+      const album = entry?.item?.album;
+      const albumUri = album?.uri ?? (album?.id ? `spotify:album:${album.id}` : '');
+      if (!albumUri) continue;
+      albums.push({ uri: albumUri, title: (album?.name ?? '').trim() });
+    }
+
+    return {
+      ok: true,
+      status: response.status,
+      albums,
+      hasNext: Boolean(data.next),
+    };
+  }
+
+  /**
+   * @param {ItemType} itemType
+   * @param {string} id
+   * @returns {Promise<string | null>}
+   */
+  async getItemTitle(itemType, id) {
+    const path = itemType === 'album' ? `/albums/${id}` : `/playlists/${id}`;
+    const response = await this.spotifyApi.request(path, { method: 'GET' }, false);
+    if (!response.ok) return null;
+
+    /** @type {{name?: string}} */
+    const data = await response.json();
+    const title = (data.name ?? '').trim();
+    return title || null;
+  }
+}

--- a/src/spotify-status-message.js
+++ b/src/spotify-status-message.js
@@ -1,0 +1,22 @@
+/**
+ * @param {number} status
+ * @param {string} fallbackMessage
+ */
+export function spotifyStatusMessage(status, fallbackMessage) {
+  if (status === 401) {
+    return 'Spotify session expired. Please reconnect.';
+  }
+  if (status === 403) {
+    return 'Spotify permissions are missing. Disconnect and reconnect.';
+  }
+  if (status === 404) {
+    return 'Requested Spotify item or playback device was not found.';
+  }
+  if (status === 429) {
+    return 'Spotify rate limit reached. Please wait a moment and retry.';
+  }
+  if (status >= 500) {
+    return 'Spotify is temporarily unavailable. Please try again shortly.';
+  }
+  return fallbackMessage;
+}


### PR DESCRIPTION
### Motivation
- Separate HTTP client and error classes from application logic to improve modularity and testability.
- Allow the Spotify API client to call back into app-specific auth/session handlers without keeping that logic inline in `src/app.js`.
- Prepare for easier reuse or replacement of the Spotify client implementation.

### Description
- Moved `SpotifyApiHttpError` and `spotifyApi` into a new module at `src/spotify-api.js` and exported them as `SpotifyApiHttpError` and `spotifyApi`.
- Added `configureSpotifyApi(...)` in `src/spotify-api.js` to accept dependency injections for `refreshSpotifyAccessToken`, `clearAuth`, `transitionToDetached`, `setAuthStatus`, and `spotifyStatusMessage`.
- Updated `src/app.js` to `import { configureSpotifyApi, spotifyApi, SpotifyApiHttpError } from './spotify-api.js'` and to call `configureSpotifyApi(...)` during startup wiring instead of defining the client inline.

### Testing
- Ran `npm run check`, which executes the test suite, and it completed successfully with the existing tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbd709f64c83219b8c554f9d7be4c7)