### PR TITLE
Run tsc and type-coverage for tests/ and ensure they always run

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,20 @@ jobs:
         run: npm ci
 
       - name: Run tsc
+        id: tsc_root
         run: npx tsc
+        continue-on-error: true
+
+      - name: Run tests tsc
+        id: tsc_tests
+        if: ${{ always() }}
+        run: npx tsc -p tests/tsconfig.json
+        continue-on-error: true
+
+      - name: Fail if tsc checks failed
+        if: ${{ always() }}
+        run: |
+          [ "${{ steps.tsc_root.outcome }}" = "success" ] && [ "${{ steps.tsc_tests.outcome }}" = "success" ]
 
   type-coverage:
     runs-on: ubuntu-latest
@@ -38,7 +51,20 @@ jobs:
         run: npm ci
 
       - name: Run type-coverage
+        id: type_coverage_root
         run: npx type-coverage
+        continue-on-error: true
+
+      - name: Run tests type-coverage
+        id: type_coverage_tests
+        if: ${{ always() }}
+        run: npx type-coverage --project tests/tsconfig.json
+        continue-on-error: true
+
+      - name: Fail if type-coverage checks failed
+        if: ${{ always() }}
+        run: |
+          [ "${{ steps.type_coverage_root.outcome }}" = "success" ] && [ "${{ steps.type_coverage_tests.outcome }}" = "success" ]
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Ensure type checking and type-coverage are performed for the `tests/` codepath and that those checks execute even if the root checks fail, so failures in either area are reported.

### Description
- Update `.github/workflows/check.yml` to run both root and `tests/` checks for `tsc` by adding a `Run tests tsc` step that runs `npx tsc -p tests/tsconfig.json` with `if: ${{ always() }}`. 
- Update `.github/workflows/check.yml` to run both root and `tests/` checks for `type-coverage` by adding a `Run tests type-coverage` step that runs `npx type-coverage --project tests/tsconfig.json` with `if: ${{ always() }}`. 
- Add `continue-on-error: true` to the root check steps and add final guard steps `Fail if tsc checks failed` and `Fail if type-coverage checks failed` (each using `if: ${{ always() }}`) so both checks always run but the job still fails when either check fails. 
- Leave the `test` job unchanged so `npm test` continues to run as before.

### Testing
- Ran the repository check script with `npm run check`, and the command completed successfully. 
- The test suite executed via `npm test` as part of `npm run check` and passed (1 test passed). 
- No automated CI run is included here; workflow changes are in `.github/workflows/check.yml` and will take effect on the next push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc1ba7f9e883218327e088c06ef5f9)