### PR TITLE
Add tests for SpotifyApi 401/refresh behavior and throwOnError variants

### DIFF
--- a/tests/spotify-api.test.js
+++ b/tests/spotify-api.test.js
@@ -25,54 +25,85 @@ function createApi() {
   return { api, state };
 }
 
-test('throws 401 and calls handleAuthExpired when no access token is available', async () => {
+/** @typedef {{ kind: 'response' | 'error'; status: number }} AuthScenarioOutcome */
+/**
+ * @typedef {{
+ * caseId: 1 | 2 | 3 | 4;
+ * accessToken: string | null;
+ * refreshedToken: string | null;
+ * throwOnError: boolean;
+ * expectedKind: AuthScenarioOutcome['kind'];
+ * expectedFetchCalls: number;
+ * }} AuthScenarioCase
+ */
+
+/**
+ * @param {AuthScenarioCase} scenario
+ * @returns {Promise<{ outcome: AuthScenarioOutcome; handleAuthExpiredCalls: number; fetchCalls: number }>}
+ */
+async function runAuth401Scenario(scenario) {
   const handleAuthExpired = mock.fn();
   const api = new SpotifyApi({
     async getAccessToken() {
-      return null;
+      return scenario.accessToken;
     },
     async refreshSpotifyAccessToken() {
-      return null;
+      return scenario.refreshedToken;
     },
     handleAuthExpired,
   });
 
-  await assert.rejects(
-    () => api.request('/me/player', { method: 'GET' }),
-    /** @param {unknown} error */
-    (error) => {
-      assert.ok(error instanceof SpotifyApiHttpError);
-      assert.equal(error.status, 401);
-      assert.match(error.message, /session expired/i);
-      return true;
-    },
-  );
-  assert.equal(handleAuthExpired.mock.callCount(), 1);
-});
+  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
+  /** @type {AuthScenarioOutcome} */
+  let outcome;
+  try {
+    const response = await api.request('/me/player', { method: 'GET' }, scenario.throwOnError);
+    outcome = { kind: 'response', status: response.status };
+  } catch (error) {
+    outcome = {
+      kind: 'error',
+      status: error instanceof SpotifyApiHttpError ? error.status : 500,
+    };
+  }
 
-test('throws 401 when no access token is available even when throwOnError is false', async () => {
-  const handleAuthExpired = mock.fn();
-  const api = new SpotifyApi({
-    async getAccessToken() {
-      return null;
-    },
-    async refreshSpotifyAccessToken() {
-      return null;
-    },
-    handleAuthExpired,
+  return {
+    outcome,
+    handleAuthExpiredCalls: handleAuthExpired.mock.callCount(),
+    fetchCalls: fetchMock.mock.callCount(),
+  };
+}
+
+/** @type {AuthScenarioCase[]} */
+const auth401Scenarios = [
+  { caseId: 1, accessToken: null, refreshedToken: null, throwOnError: false, expectedKind: 'error', expectedFetchCalls: 0 },
+  { caseId: 2, accessToken: null, refreshedToken: null, throwOnError: true, expectedKind: 'error', expectedFetchCalls: 0 },
+  {
+    caseId: 3,
+    accessToken: 'initial-token',
+    refreshedToken: null,
+    throwOnError: false,
+    expectedKind: 'response',
+    expectedFetchCalls: 1,
+  },
+  {
+    caseId: 4,
+    accessToken: 'initial-token',
+    refreshedToken: null,
+    throwOnError: true,
+    expectedKind: 'error',
+    expectedFetchCalls: 1,
+  },
+];
+
+for (const scenario of auth401Scenarios) {
+  test(`case ${scenario.caseId}: expected auth behavior`, async () => {
+    const result = await runAuth401Scenario(scenario);
+
+    assert.deepEqual(result.outcome, { kind: scenario.expectedKind, status: 401 });
+    assert.equal(result.handleAuthExpiredCalls, 1);
+    assert.equal(result.fetchCalls, scenario.expectedFetchCalls);
   });
-
-  await assert.rejects(
-    () => api.request('/me/player', { method: 'GET' }, false),
-    /** @param {unknown} error */
-    (error) => {
-      assert.ok(error instanceof SpotifyApiHttpError);
-      assert.equal(error.status, 401);
-      return true;
-    },
-  );
-  assert.equal(handleAuthExpired.mock.callCount(), 1);
-});
+}
 
 test('retries once with refreshed token after 401 and succeeds', async () => {
   const { api, state } = createApi();
@@ -97,53 +128,6 @@ test('retries once with refreshed token after 401 and succeeds', async () => {
   const secondHeaders = /** @type {Record<string, string>} */ (secondCall?.arguments[1]?.headers);
   assert.equal(firstHeaders.Authorization, 'Bearer initial-token');
   assert.equal(secondHeaders.Authorization, 'Bearer refreshed-token');
-});
-
-test('returns 401 response after failed refresh when throwOnError is false', async () => {
-  const handleAuthExpired = mock.fn();
-  const api = new SpotifyApi({
-    async getAccessToken() {
-      return 'initial-token';
-    },
-    async refreshSpotifyAccessToken() {
-      return null;
-    },
-    handleAuthExpired,
-  });
-
-  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
-
-  const response = await api.request('/me/player', { method: 'GET' }, false);
-  assert.equal(response.status, 401);
-  assert.equal(fetchMock.mock.callCount(), 1);
-  assert.equal(handleAuthExpired.mock.callCount(), 1);
-});
-
-test('throws 401 after failed refresh when throwOnError is true', async () => {
-  const handleAuthExpired = mock.fn();
-  const api = new SpotifyApi({
-    async getAccessToken() {
-      return 'initial-token';
-    },
-    async refreshSpotifyAccessToken() {
-      return null;
-    },
-    handleAuthExpired,
-  });
-
-  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
-
-  await assert.rejects(
-    () => api.request('/me/player', { method: 'GET' }, true),
-    /** @param {unknown} error */
-    (error) => {
-      assert.ok(error instanceof SpotifyApiHttpError);
-      assert.equal(error.status, 401);
-      return true;
-    },
-  );
-  assert.equal(fetchMock.mock.callCount(), 1);
-  assert.equal(handleAuthExpired.mock.callCount(), 1);
 });
 
 test('throws with status text and body for non-ok responses', async () => {
@@ -178,90 +162,15 @@ test(
   'TODO: cases 1 and 3 should produce the same result',
   { todo: 'Case 1 throws while case 3 returns a 401 response when throwOnError is false.' },
   async () => {
-    const case1Api = new SpotifyApi({
-      async getAccessToken() {
-        return null;
-      },
-      async refreshSpotifyAccessToken() {
-        return null;
-      },
-      handleAuthExpired() {},
-    });
-
-    const case3Api = new SpotifyApi({
-      async getAccessToken() {
-        return 'initial-token';
-      },
-      async refreshSpotifyAccessToken() {
-        return null;
-      },
-      handleAuthExpired() {},
-    });
-
-    mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
-
-    const case1Result = await case1Api
-      .request('/me/player', { method: 'GET' }, false)
-      .then((response) => ({ kind: 'response', status: response.status }))
-      .catch(
-        /** @param {unknown} error */
-        (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
-      );
-
-    const case3Result = await case3Api
-      .request('/me/player', { method: 'GET' }, false)
-      .then((response) => ({ kind: 'response', status: response.status }))
-      .catch(
-        /** @param {unknown} error */
-        (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
-      );
-
-    assert.deepEqual(case1Result, case3Result);
+    const case1Result = await runAuth401Scenario(auth401Scenarios[0]);
+    const case3Result = await runAuth401Scenario(auth401Scenarios[2]);
+    assert.deepEqual(case1Result.outcome, case3Result.outcome);
   },
 );
 
 test('cases 2 and 4 produce the same result', async () => {
-  const case2HandleAuthExpired = mock.fn();
-  const case2Api = new SpotifyApi({
-    async getAccessToken() {
-      return null;
-    },
-    async refreshSpotifyAccessToken() {
-      return null;
-    },
-    handleAuthExpired: case2HandleAuthExpired,
-  });
-
-  const case4HandleAuthExpired = mock.fn();
-  const case4Api = new SpotifyApi({
-    async getAccessToken() {
-      return 'initial-token';
-    },
-    async refreshSpotifyAccessToken() {
-      return null;
-    },
-    handleAuthExpired: case4HandleAuthExpired,
-  });
-
-  mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
-
-  const case2Result = await case2Api
-    .request('/me/player', { method: 'GET' }, true)
-    .then((response) => ({ kind: 'response', status: response.status }))
-    .catch(
-      /** @param {unknown} error */
-      (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
-    );
-
-  const case4Result = await case4Api
-    .request('/me/player', { method: 'GET' }, true)
-    .then((response) => ({ kind: 'response', status: response.status }))
-    .catch(
-      /** @param {unknown} error */
-      (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
-    );
-
-  assert.deepEqual(case2Result, case4Result);
-  assert.equal(case2HandleAuthExpired.mock.callCount(), 1);
-  assert.equal(case4HandleAuthExpired.mock.callCount(), 1);
+  const case2Result = await runAuth401Scenario(auth401Scenarios[1]);
+  const case4Result = await runAuth401Scenario(auth401Scenarios[3]);
+  assert.deepEqual(case2Result.outcome, case4Result.outcome);
+  assert.equal(case2Result.handleAuthExpiredCalls, case4Result.handleAuthExpiredCalls);
 });

--- a/tests/spotify-api.test.js
+++ b/tests/spotify-api.test.js
@@ -7,63 +7,65 @@ afterEach(() => {
   mock.restoreAll();
 });
 
-/** @typedef {{ refreshedToken: string | null }} DepState */
-
-/** @returns {{ api: SpotifyApi; state: DepState }} */
-function createApi() {
-  /** @type {DepState} */
-  const state = { refreshedToken: null };
-  const api = new SpotifyApi({
-    async getAccessToken() {
-      return 'initial-token';
-    },
-    async refreshSpotifyAccessToken() {
-      return state.refreshedToken;
-    },
-    handleAuthExpired() {},
-  });
-  return { api, state };
-}
-
-/** @typedef {{ kind: 'response' | 'error'; status: number }} AuthScenarioOutcome */
+/** @typedef {{ kind: 'response' | 'error'; status: number }} RequestOutcome */
 /**
  * @typedef {{
- * caseId: 1 | 2 | 3 | 4;
+ * name: string;
  * accessToken: string | null;
  * refreshedToken: string | null;
  * throwOnError: boolean;
- * expectedKind: AuthScenarioOutcome['kind'];
+ * fetchStatuses: number[];
+ * expectedOutcome: RequestOutcome;
+ * expectedHandleAuthExpiredCalls: number;
  * expectedFetchCalls: number;
- * }} AuthScenarioCase
+ * }} AuthCase
  */
 
 /**
- * @param {AuthScenarioCase} scenario
- * @returns {Promise<{ outcome: AuthScenarioOutcome; handleAuthExpiredCalls: number; fetchCalls: number }>}
+ * @param {{ accessToken: string | null; refreshedToken: string | null; handleAuthExpired: () => void }} deps
+ * @returns {SpotifyApi}
  */
-async function runAuth401Scenario(scenario) {
-  const handleAuthExpired = mock.fn();
-  const api = new SpotifyApi({
+function createApi(deps) {
+  return new SpotifyApi({
     async getAccessToken() {
-      return scenario.accessToken;
+      return deps.accessToken;
     },
     async refreshSpotifyAccessToken() {
-      return scenario.refreshedToken;
+      return deps.refreshedToken;
     },
+    handleAuthExpired: deps.handleAuthExpired,
+  });
+}
+
+/**
+ * @param {AuthCase} authCase
+ * @returns {Promise<{ outcome: RequestOutcome; handleAuthExpiredCalls: number; fetchCalls: number }>}
+ */
+async function runAuthCase(authCase) {
+  const handleAuthExpired = mock.fn();
+  const api = createApi({
+    accessToken: authCase.accessToken,
+    refreshedToken: authCase.refreshedToken,
     handleAuthExpired,
   });
 
-  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
-  /** @type {AuthScenarioOutcome} */
+  let fetchCallIndex = 0;
+  const fetchMock = mock.method(globalThis, 'fetch', async () => {
+    const status = authCase.fetchStatuses[fetchCallIndex] ?? 500;
+    fetchCallIndex += 1;
+    return new Response('', { status });
+  });
+
+  /** @type {RequestOutcome} */
   let outcome;
   try {
-    const response = await api.request('/me/player', { method: 'GET' }, scenario.throwOnError);
+    const response = await api.request('/me/player', { method: 'GET' }, authCase.throwOnError);
     outcome = { kind: 'response', status: response.status };
   } catch (error) {
-    outcome = {
-      kind: 'error',
-      status: error instanceof SpotifyApiHttpError ? error.status : 500,
-    };
+    if (!(error instanceof SpotifyApiHttpError)) {
+      assert.fail('Expected SpotifyApiHttpError');
+    }
+    outcome = { kind: 'error', status: error.status };
   }
 
   return {
@@ -73,104 +75,173 @@ async function runAuth401Scenario(scenario) {
   };
 }
 
-/** @type {AuthScenarioCase[]} */
-const auth401Scenarios = [
-  { caseId: 1, accessToken: null, refreshedToken: null, throwOnError: false, expectedKind: 'error', expectedFetchCalls: 0 },
-  { caseId: 2, accessToken: null, refreshedToken: null, throwOnError: true, expectedKind: 'error', expectedFetchCalls: 0 },
+/** @type {AuthCase[]} */
+const authCases = [
   {
-    caseId: 3,
+    name: 'no access token with throwOnError false',
+    accessToken: null,
+    refreshedToken: null,
+    throwOnError: false,
+    fetchStatuses: [],
+    expectedOutcome: { kind: 'error', status: 401 },
+    expectedHandleAuthExpiredCalls: 1,
+    expectedFetchCalls: 0,
+  },
+  {
+    name: 'no access token with throwOnError true',
+    accessToken: null,
+    refreshedToken: null,
+    throwOnError: true,
+    fetchStatuses: [],
+    expectedOutcome: { kind: 'error', status: 401 },
+    expectedHandleAuthExpiredCalls: 1,
+    expectedFetchCalls: 0,
+  },
+  {
+    name: 'refresh returns null after 401 with throwOnError false',
     accessToken: 'initial-token',
     refreshedToken: null,
     throwOnError: false,
-    expectedKind: 'response',
+    fetchStatuses: [401],
+    expectedOutcome: { kind: 'response', status: 401 },
+    expectedHandleAuthExpiredCalls: 1,
     expectedFetchCalls: 1,
   },
   {
-    caseId: 4,
+    name: 'refresh returns null after 401 with throwOnError true',
     accessToken: 'initial-token',
     refreshedToken: null,
     throwOnError: true,
-    expectedKind: 'error',
+    fetchStatuses: [401],
+    expectedOutcome: { kind: 'error', status: 401 },
+    expectedHandleAuthExpiredCalls: 1,
     expectedFetchCalls: 1,
+  },
+  {
+    name: '401 response after refresh returns non-null with throwOnError false',
+    accessToken: 'initial-token',
+    refreshedToken: 'refreshed-token',
+    throwOnError: false,
+    fetchStatuses: [401, 401],
+    expectedOutcome: { kind: 'response', status: 401 },
+    expectedHandleAuthExpiredCalls: 1,
+    expectedFetchCalls: 2,
   },
 ];
 
-for (const scenario of auth401Scenarios) {
-  test(`case ${scenario.caseId}: expected auth behavior`, async () => {
-    const result = await runAuth401Scenario(scenario);
+/**
+ * @typedef {{
+ * name: string;
+ * todo?: string;
+ * run: () => Promise<void>;
+ * }} TableTest
+ */
 
-    assert.deepEqual(result.outcome, { kind: scenario.expectedKind, status: 401 });
-    assert.equal(result.handleAuthExpiredCalls, 1);
-    assert.equal(result.fetchCalls, scenario.expectedFetchCalls);
-  });
-}
-
-test('retries once with refreshed token after 401 and succeeds', async () => {
-  const { api, state } = createApi();
-  state.refreshedToken = 'refreshed-token';
-
-  const fetchMock = mock.method(globalThis, 'fetch', async () => {
-    if (fetchMock.mock.callCount() === 0) {
-      return new Response('', { status: 401 });
-    }
-    return new Response('{"ok":true}', { status: 200 });
-  });
-
-  const response = await api.request('/tracks/abc', { method: 'GET' });
-  assert.equal(response.status, 200);
-  assert.equal(fetchMock.mock.callCount(), 2);
-
-  const firstCall = fetchMock.mock.calls[0];
-  const secondCall = fetchMock.mock.calls[1];
-  assert.equal(String(firstCall?.arguments[0]), 'https://api.spotify.com/v1/tracks/abc');
-
-  const firstHeaders = /** @type {Record<string, string>} */ (firstCall?.arguments[1]?.headers);
-  const secondHeaders = /** @type {Record<string, string>} */ (secondCall?.arguments[1]?.headers);
-  assert.equal(firstHeaders.Authorization, 'Bearer initial-token');
-  assert.equal(secondHeaders.Authorization, 'Bearer refreshed-token');
-});
-
-test('throws with status text and body for non-ok responses', async () => {
-  const { api } = createApi();
-
-  mock.method(globalThis, 'fetch', async () => new Response('extra details', { status: 404 }));
-
-  await assert.rejects(
-    () => api.request('/albums/missing', { method: 'GET' }),
-    /** @param {unknown} error */
-    (error) => {
-      assert.ok(error instanceof SpotifyApiHttpError);
-      assert.equal(error.status, 404);
-      assert.match(error.message, /not found/i);
-      assert.match(error.message, /extra details/i);
-      return true;
+/** @type {TableTest[]} */
+const tableTests = [
+  ...authCases.map((authCase) => ({
+    name: `auth case: ${authCase.name}`,
+    run: async () => {
+      const result = await runAuthCase(authCase);
+      assert.deepEqual(result.outcome, authCase.expectedOutcome);
+      assert.equal(result.handleAuthExpiredCalls, authCase.expectedHandleAuthExpiredCalls);
+      assert.equal(result.fetchCalls, authCase.expectedFetchCalls);
     },
-  );
-});
+  })),
+  {
+    name: 'retries once with refreshed token after 401 and succeeds',
+    run: async () => {
+      const api = createApi({
+        accessToken: 'initial-token',
+        refreshedToken: 'refreshed-token',
+        handleAuthExpired() {},
+      });
 
-test('returns non-ok response when throwOnError is false', async () => {
-  const { api } = createApi();
+      const fetchMock = mock.method(globalThis, 'fetch', async () => {
+        if (fetchMock.mock.callCount() === 0) {
+          return new Response('', { status: 401 });
+        }
+        return new Response('{"ok":true}', { status: 200 });
+      });
 
-  mock.method(globalThis, 'fetch', async () => new Response('bad request', { status: 400 }));
+      const response = await api.request('/tracks/abc', { method: 'GET' });
+      assert.equal(response.status, 200);
+      assert.equal(fetchMock.mock.callCount(), 2);
 
-  const response = await api.request('/me/player', { method: 'GET' }, false);
-  assert.equal(response.ok, false);
-  assert.equal(response.status, 400);
-});
+      const firstCall = fetchMock.mock.calls[0];
+      const secondCall = fetchMock.mock.calls[1];
+      assert.equal(String(firstCall?.arguments[0]), 'https://api.spotify.com/v1/tracks/abc');
 
-test(
-  'TODO: cases 1 and 3 should produce the same result',
-  { todo: 'Case 1 throws while case 3 returns a 401 response when throwOnError is false.' },
-  async () => {
-    const case1Result = await runAuth401Scenario(auth401Scenarios[0]);
-    const case3Result = await runAuth401Scenario(auth401Scenarios[2]);
-    assert.deepEqual(case1Result.outcome, case3Result.outcome);
+      const firstHeaders = /** @type {Record<string, string>} */ (firstCall?.arguments[1]?.headers);
+      const secondHeaders = /** @type {Record<string, string>} */ (secondCall?.arguments[1]?.headers);
+      assert.equal(firstHeaders.Authorization, 'Bearer initial-token');
+      assert.equal(secondHeaders.Authorization, 'Bearer refreshed-token');
+    },
   },
-);
+  {
+    name: 'throws with status text and body for non-ok responses',
+    run: async () => {
+      const api = createApi({
+        accessToken: 'initial-token',
+        refreshedToken: null,
+        handleAuthExpired() {},
+      });
 
-test('cases 2 and 4 produce the same result', async () => {
-  const case2Result = await runAuth401Scenario(auth401Scenarios[1]);
-  const case4Result = await runAuth401Scenario(auth401Scenarios[3]);
-  assert.deepEqual(case2Result.outcome, case4Result.outcome);
-  assert.equal(case2Result.handleAuthExpiredCalls, case4Result.handleAuthExpiredCalls);
-});
+      mock.method(globalThis, 'fetch', async () => new Response('extra details', { status: 404 }));
+
+      await assert.rejects(
+        () => api.request('/albums/missing', { method: 'GET' }),
+        /** @param {unknown} error */
+        (error) => {
+          assert.ok(error instanceof SpotifyApiHttpError);
+          assert.equal(error.status, 404);
+          assert.match(error.message, /not found/i);
+          assert.match(error.message, /extra details/i);
+          return true;
+        },
+      );
+    },
+  },
+  {
+    name: 'returns non-ok response when throwOnError is false',
+    run: async () => {
+      const api = createApi({
+        accessToken: 'initial-token',
+        refreshedToken: null,
+        handleAuthExpired() {},
+      });
+
+      mock.method(globalThis, 'fetch', async () => new Response('bad request', { status: 400 }));
+
+      const response = await api.request('/me/player', { method: 'GET' }, false);
+      assert.equal(response.ok, false);
+      assert.equal(response.status, 400);
+    },
+  },
+  {
+    name: 'cases no access token with throwOnError false and refresh returns null after 401 with throwOnError false produce the same result',
+    todo: 'No-token path throws while refresh-null path returns response when throwOnError is false.',
+    run: async () => {
+      const noTokenFalse = await runAuthCase(authCases[0]);
+      const refreshNullFalse = await runAuthCase(authCases[2]);
+      assert.deepEqual(noTokenFalse.outcome, refreshNullFalse.outcome);
+    },
+  },
+  {
+    name: 'cases no access token with throwOnError true and refresh returns null after 401 with throwOnError true produce the same result',
+    run: async () => {
+      const noTokenTrue = await runAuthCase(authCases[1]);
+      const refreshNullTrue = await runAuthCase(authCases[3]);
+      assert.deepEqual(noTokenTrue.outcome, refreshNullTrue.outcome);
+      assert.equal(noTokenTrue.handleAuthExpiredCalls, refreshNullTrue.handleAuthExpiredCalls);
+    },
+  },
+];
+
+for (const tableTest of tableTests) {
+  if (tableTest.todo) {
+    test(tableTest.name, { todo: tableTest.todo }, tableTest.run);
+  } else {
+    test(tableTest.name, tableTest.run);
+  }
+}

--- a/tests/spotify-api.test.js
+++ b/tests/spotify-api.test.js
@@ -50,6 +50,30 @@ test('throws 401 and calls handleAuthExpired when no access token is available',
   assert.equal(handleAuthExpired.mock.callCount(), 1);
 });
 
+test('throws 401 when no access token is available even when throwOnError is false', async () => {
+  const handleAuthExpired = mock.fn();
+  const api = new SpotifyApi({
+    async getAccessToken() {
+      return null;
+    },
+    async refreshSpotifyAccessToken() {
+      return null;
+    },
+    handleAuthExpired,
+  });
+
+  await assert.rejects(
+    () => api.request('/me/player', { method: 'GET' }, false),
+    /** @param {unknown} error */
+    (error) => {
+      assert.ok(error instanceof SpotifyApiHttpError);
+      assert.equal(error.status, 401);
+      return true;
+    },
+  );
+  assert.equal(handleAuthExpired.mock.callCount(), 1);
+});
+
 test('retries once with refreshed token after 401 and succeeds', async () => {
   const { api, state } = createApi();
   state.refreshedToken = 'refreshed-token';
@@ -73,6 +97,53 @@ test('retries once with refreshed token after 401 and succeeds', async () => {
   const secondHeaders = /** @type {Record<string, string>} */ (secondCall?.arguments[1]?.headers);
   assert.equal(firstHeaders.Authorization, 'Bearer initial-token');
   assert.equal(secondHeaders.Authorization, 'Bearer refreshed-token');
+});
+
+test('returns 401 response after failed refresh when throwOnError is false', async () => {
+  const handleAuthExpired = mock.fn();
+  const api = new SpotifyApi({
+    async getAccessToken() {
+      return 'initial-token';
+    },
+    async refreshSpotifyAccessToken() {
+      return null;
+    },
+    handleAuthExpired,
+  });
+
+  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
+
+  const response = await api.request('/me/player', { method: 'GET' }, false);
+  assert.equal(response.status, 401);
+  assert.equal(fetchMock.mock.callCount(), 1);
+  assert.equal(handleAuthExpired.mock.callCount(), 1);
+});
+
+test('throws 401 after failed refresh when throwOnError is true', async () => {
+  const handleAuthExpired = mock.fn();
+  const api = new SpotifyApi({
+    async getAccessToken() {
+      return 'initial-token';
+    },
+    async refreshSpotifyAccessToken() {
+      return null;
+    },
+    handleAuthExpired,
+  });
+
+  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
+
+  await assert.rejects(
+    () => api.request('/me/player', { method: 'GET' }, true),
+    /** @param {unknown} error */
+    (error) => {
+      assert.ok(error instanceof SpotifyApiHttpError);
+      assert.equal(error.status, 401);
+      return true;
+    },
+  );
+  assert.equal(fetchMock.mock.callCount(), 1);
+  assert.equal(handleAuthExpired.mock.callCount(), 1);
 });
 
 test('throws with status text and body for non-ok responses', async () => {
@@ -101,4 +172,96 @@ test('returns non-ok response when throwOnError is false', async () => {
   const response = await api.request('/me/player', { method: 'GET' }, false);
   assert.equal(response.ok, false);
   assert.equal(response.status, 400);
+});
+
+test(
+  'TODO: cases 1 and 3 should produce the same result',
+  { todo: 'Case 1 throws while case 3 returns a 401 response when throwOnError is false.' },
+  async () => {
+    const case1Api = new SpotifyApi({
+      async getAccessToken() {
+        return null;
+      },
+      async refreshSpotifyAccessToken() {
+        return null;
+      },
+      handleAuthExpired() {},
+    });
+
+    const case3Api = new SpotifyApi({
+      async getAccessToken() {
+        return 'initial-token';
+      },
+      async refreshSpotifyAccessToken() {
+        return null;
+      },
+      handleAuthExpired() {},
+    });
+
+    mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
+
+    const case1Result = await case1Api
+      .request('/me/player', { method: 'GET' }, false)
+      .then((response) => ({ kind: 'response', status: response.status }))
+      .catch(
+        /** @param {unknown} error */
+        (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
+      );
+
+    const case3Result = await case3Api
+      .request('/me/player', { method: 'GET' }, false)
+      .then((response) => ({ kind: 'response', status: response.status }))
+      .catch(
+        /** @param {unknown} error */
+        (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
+      );
+
+    assert.deepEqual(case1Result, case3Result);
+  },
+);
+
+test('cases 2 and 4 produce the same result', async () => {
+  const case2HandleAuthExpired = mock.fn();
+  const case2Api = new SpotifyApi({
+    async getAccessToken() {
+      return null;
+    },
+    async refreshSpotifyAccessToken() {
+      return null;
+    },
+    handleAuthExpired: case2HandleAuthExpired,
+  });
+
+  const case4HandleAuthExpired = mock.fn();
+  const case4Api = new SpotifyApi({
+    async getAccessToken() {
+      return 'initial-token';
+    },
+    async refreshSpotifyAccessToken() {
+      return null;
+    },
+    handleAuthExpired: case4HandleAuthExpired,
+  });
+
+  mock.method(globalThis, 'fetch', async () => new Response('', { status: 401 }));
+
+  const case2Result = await case2Api
+    .request('/me/player', { method: 'GET' }, true)
+    .then((response) => ({ kind: 'response', status: response.status }))
+    .catch(
+      /** @param {unknown} error */
+      (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
+    );
+
+  const case4Result = await case4Api
+    .request('/me/player', { method: 'GET' }, true)
+    .then((response) => ({ kind: 'response', status: response.status }))
+    .catch(
+      /** @param {unknown} error */
+      (error) => ({ kind: 'error', status: /** @type {SpotifyApiHttpError} */ (error).status }),
+    );
+
+  assert.deepEqual(case2Result, case4Result);
+  assert.equal(case2HandleAuthExpired.mock.callCount(), 1);
+  assert.equal(case4HandleAuthExpired.mock.callCount(), 1);
 });


### PR DESCRIPTION
### Motivation

- Ensure `SpotifyApi.request` behavior is covered for combinations of missing/initial access tokens, failed refreshes, and the `throwOnError` flag, and verify `handleAuthExpired` is invoked appropriately.
- Surface and document an observed inconsistency between cases where no token is available vs an initial token with failed refresh by adding a `todo` spec. 

### Description

- Added multiple tests to `tests/spotify-api.test.js` covering: the case where no access token is available when `throwOnError` is `false`, failed token refresh with `throwOnError` `false` returning a 401 response, and failed token refresh with `throwOnError` `true` throwing a `SpotifyApiHttpError` with status `401`.
- Kept and asserted existing behavior for retrying once after a `401` and succeeding when refresh yields a new token.
- Added two comparison tests: one marked `todo` that highlights a mismatch between two scenarios, and another that verifies two other cases produce the same result and that `handleAuthExpired` is called exactly once in each.
- All new tests use mocked `fetch` calls and mock handlers for `getAccessToken`, `refreshSpotifyAccessToken`, and `handleAuthExpired`.

### Testing

- Ran the unit test suite with `npm test` and executed `tests/spotify-api.test.js` which includes the new tests; all tests completed successfully and the `todo` test remains marked as todo so it does not cause failures.
- Verified specific new tests such as `throws 401 when no access token is available even when throwOnError is false`, `returns 401 response after failed refresh when throwOnError is false`, and `throws 401 after failed refresh when throwOnError is true` ran and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd03929da48321b8db4ae73d7d5e4e)