### PR TITLE
Extract playback monitor into dedicated module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -94,7 +94,7 @@ const spotifyAppApi = new SpotifyAppApi(spotifyApi);
 const playerMonitor = new PlayerMonitor({
   getSession: () => session,
   getUsableAccessToken,
-  getPlayerState: () => spotifyAppApi.getPlayerState(),
+  spotifyAppApi,
   persistRuntimeState,
   transitionToDetached,
   goToNextItem,

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
 import { SpotifyAppApi } from './spotify-app-api.js';
 import { spotifyStatusMessage } from './spotify-status-message.js';
-import { createPlayerMonitor } from './player-monitor.js';
+import { PlayerMonitor } from './player-monitor.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -91,7 +91,7 @@ const spotifyApi = new SpotifyApi({
 const spotifyAppApi = new SpotifyAppApi(spotifyApi);
 
 
-const playerMonitor = createPlayerMonitor({
+const playerMonitor = new PlayerMonitor({
   getSession: () => session,
   getUsableAccessToken,
   getPlayerState: () => spotifyAppApi.getPlayerState(),

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
 import { SpotifyAppApi } from './spotify-app-api.js';
 import { spotifyStatusMessage } from './spotify-status-message.js';
-import { PlayerMonitor } from './player-monitor.js';
+import { PlayerMonitor, PlayerMonitorStatusError } from './player-monitor.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -98,7 +98,7 @@ const playerMonitor = new PlayerMonitor({
   persistRuntimeState,
   transitionToDetached,
   goToNextItem,
-  reportError,
+  reportError: reportMonitorError,
   isUnrecoverableSpotifyStatus,
 });
 
@@ -1098,6 +1098,28 @@ async function runWithReportedError(task, reportErrorOptions) {
     reportError(error, reportErrorOptions);
     return undefined;
   }
+}
+
+/** @param {unknown} error */
+function reportMonitorError(error) {
+  if (error instanceof PlayerMonitorStatusError) {
+    reportError(error, {
+      context: 'monitor',
+      fallbackMessage: spotifyStatusMessage(error.status, 'Could not check playback state.'),
+      playbackStatusMessage: 'Unable to check playback state right now.',
+      toastMode: 'cooldown',
+      toastKey: `monitor-http-${error.status}`,
+    });
+    return;
+  }
+
+  reportError(error, {
+    context: 'monitor',
+    fallbackMessage: 'Playback monitor encountered an error.',
+    playbackStatusMessage: 'Playback monitor paused due to an error. Try restarting the session.',
+    toastMode: 'cooldown',
+    toastKey: 'monitor-loop',
+  });
 }
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { SpotifyApi, SpotifyApiHttpError } from './spotify-api.js';
 import { SpotifyAppApi } from './spotify-app-api.js';
 import { spotifyStatusMessage } from './spotify-status-message.js';
+import { createPlayerMonitor } from './player-monitor.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 
@@ -75,7 +76,6 @@ const session = {
   observedCurrentContext: false,
 };
 
-let monitorTimer = /** @type {number | null} */ (null);
 const TOAST_DURATION_MS = 5000;
 const ERROR_TOAST_COOLDOWN_MS = 45000;
 /** @type {Map<string, number>} */
@@ -89,6 +89,18 @@ const spotifyApi = new SpotifyApi({
   handleAuthExpired,
 });
 const spotifyAppApi = new SpotifyAppApi(spotifyApi);
+
+
+const playerMonitor = createPlayerMonitor({
+  getSession: () => session,
+  getUsableAccessToken,
+  getPlayerState: () => spotifyAppApi.getPlayerState(),
+  persistRuntimeState,
+  transitionToDetached,
+  goToNextItem,
+  reportError,
+  isUnrecoverableSpotifyStatus,
+});
 
 void runWithReportedError(bootstrap, {
   context: 'startup',
@@ -705,7 +717,7 @@ async function startShuffleSession() {
   setPlaybackStatus(`Session started with ${session.queue.length} item(s).`);
   await playCurrentItem();
   if (session.activationState === 'active') {
-    startMonitorLoop();
+    playerMonitor.start();
   }
 }
 
@@ -716,7 +728,7 @@ function stopSession(message) {
 
 /** @param {string} message */
 function transitionToInactive(message) {
-  stopMonitorLoop();
+  playerMonitor.stop();
   session.activationState = 'inactive';
   session.queue = [];
   session.index = 0;
@@ -733,18 +745,11 @@ function transitionToDetached(message) {
   if (session.activationState === 'inactive') {
     return;
   }
-  stopMonitorLoop();
+  playerMonitor.stop();
   session.activationState = 'detached';
   persistRuntimeState();
   renderPlaybackControls();
   setPlaybackStatus(message);
-}
-
-function stopMonitorLoop() {
-  if (monitorTimer !== null) {
-    clearInterval(monitorTimer);
-    monitorTimer = null;
-  }
 }
 
 function renderPlaybackControls() {
@@ -817,7 +822,7 @@ async function reattachSession() {
     setPlaybackStatus(formatNowPlayingStatus(current));
   }
   if (session.activationState === 'active') {
-    startMonitorLoop();
+    playerMonitor.start();
   }
 }
 
@@ -956,69 +961,6 @@ function spotifyIdFromUri(uri) {
   return match ? match[2] : null;
 }
 
-function startMonitorLoop() {
-  stopMonitorLoop();
-  monitorTimer = window.setInterval(() => {
-    void runWithReportedError(() => monitorPlayback(), {
-      context: 'monitor',
-      fallbackMessage: 'Playback monitor encountered an error.',
-      playbackStatusMessage: 'Playback monitor paused due to an error. Try restarting the session.',
-      toastMode: 'cooldown',
-      toastKey: 'monitor-loop',
-    });
-  }, 4000);
-}
-
-async function monitorPlayback() {
-  if (session.activationState !== 'active' || !session.currentUri) return;
-  const token = await getUsableAccessToken();
-  if (!token) {
-    transitionToDetached('Spotify session expired. Please reconnect.');
-    return;
-  }
-
-  const playerState = await spotifyAppApi.getPlayerState();
-  if (!playerState.ok) {
-    if (isUnrecoverableSpotifyStatus(playerState.status)) {
-      transitionToDetached(spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'));
-      return;
-    }
-    reportError(new Error(`Playback monitor request failed (${playerState.status}): ${playerState.errorText}`), {
-      context: 'monitor',
-      fallbackMessage: spotifyStatusMessage(playerState.status, 'Could not check playback state.'),
-      playbackStatusMessage: 'Unable to check playback state right now.',
-      toastMode: 'cooldown',
-      toastKey: `monitor-http-${playerState.status}`,
-    });
-    return;
-  }
-
-  const contextUri = playerState.contextUri;
-
-  if (contextUri === session.currentUri) {
-    session.observedCurrentContext = true;
-    persistRuntimeState();
-    return;
-  }
-
-  if (!session.observedCurrentContext) {
-    // Ignore transient mismatch while a new context is still starting.
-    return;
-  }
-
-  if (session.observedCurrentContext && contextUri === null) {
-    // Current context is no longer active (likely finished).
-    await goToNextItem();
-    return;
-  }
-
-  if (contextUri && contextUri !== session.currentUri) {
-    transitionToDetached(
-      'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
-    );
-  }
-}
-
 function restoreRuntimeState() {
   const raw = localStorage.getItem(STORAGE_KEYS.runtime);
   if (!raw) return;
@@ -1097,7 +1039,7 @@ function restoreRuntimeState() {
   renderSessionQueue();
   renderPlaybackControls();
   if (session.activationState === 'active') {
-    startMonitorLoop();
+    playerMonitor.start();
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1116,7 +1116,7 @@ function reportMonitorError(error) {
   reportError(error, {
     context: 'monitor',
     fallbackMessage: 'Playback monitor encountered an error.',
-    playbackStatusMessage: 'Playback monitor paused due to an error. Try restarting the session.',
+    playbackStatusMessage: 'Playback monitor encountered an error.',
     toastMode: 'cooldown',
     toastKey: 'monitor-loop',
   });

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -48,7 +48,20 @@ export class PlayerMonitor {
   start() {
     this.stop();
     this.monitorTimer = window.setInterval(() => {
-      void this.monitorPlayback();
+      void (async () => {
+        try {
+          await this.monitorPlayback();
+        } catch (error) {
+          this.deps.reportError(error, {
+            context: 'monitor',
+            fallbackMessage: 'Playback monitor encountered an error.',
+            playbackStatusMessage:
+              'Playback monitor paused due to an error. Try restarting the session.',
+            toastMode: 'cooldown',
+            toastKey: 'monitor-loop',
+          });
+        }
+      })();
     }, 4000);
   }
 
@@ -69,65 +82,54 @@ export class PlayerMonitor {
       return;
     }
 
-    try {
-      const playerState = await this.deps.getPlayerState();
-      if (!playerState.ok) {
-        if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
-          this.deps.transitionToDetached(
-            spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'),
-          );
-          return;
-        }
-
-        this.deps.reportError(
-          new Error(
-            `Playback monitor request failed (${playerState.status}): ${playerState.errorText}`,
-          ),
-          {
-            context: 'monitor',
-            fallbackMessage: spotifyStatusMessage(
-              playerState.status,
-              'Could not check playback state.',
-            ),
-            playbackStatusMessage: 'Unable to check playback state right now.',
-            toastMode: 'cooldown',
-            toastKey: `monitor-http-${playerState.status}`,
-          },
-        );
-        return;
-      }
-
-      const contextUri = playerState.contextUri;
-
-      if (contextUri === session.currentUri) {
-        session.observedCurrentContext = true;
-        this.deps.persistRuntimeState();
-        return;
-      }
-
-      if (!session.observedCurrentContext) {
-        return;
-      }
-
-      if (session.observedCurrentContext && contextUri === null) {
-        await this.deps.goToNextItem();
-        return;
-      }
-
-      if (contextUri && contextUri !== session.currentUri) {
+    const playerState = await this.deps.getPlayerState();
+    if (!playerState.ok) {
+      if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
         this.deps.transitionToDetached(
-          'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
+          spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'),
         );
+        return;
       }
-    } catch (error) {
-      this.deps.reportError(error, {
-        context: 'monitor',
-        fallbackMessage: 'Playback monitor encountered an error.',
-        playbackStatusMessage:
-          'Playback monitor paused due to an error. Try restarting the session.',
-        toastMode: 'cooldown',
-        toastKey: 'monitor-loop',
-      });
+
+      this.deps.reportError(
+        new Error(
+          `Playback monitor request failed (${playerState.status}): ${playerState.errorText}`,
+        ),
+        {
+          context: 'monitor',
+          fallbackMessage: spotifyStatusMessage(
+            playerState.status,
+            'Could not check playback state.',
+          ),
+          playbackStatusMessage: 'Unable to check playback state right now.',
+          toastMode: 'cooldown',
+          toastKey: `monitor-http-${playerState.status}`,
+        },
+      );
+      return;
+    }
+
+    const contextUri = playerState.contextUri;
+
+    if (contextUri === session.currentUri) {
+      session.observedCurrentContext = true;
+      this.deps.persistRuntimeState();
+      return;
+    }
+
+    if (!session.observedCurrentContext) {
+      return;
+    }
+
+    if (session.observedCurrentContext && contextUri === null) {
+      await this.deps.goToNextItem();
+      return;
+    }
+
+    if (contextUri && contextUri !== session.currentUri) {
+      this.deps.transitionToDetached(
+        'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
+      );
     }
   }
 }

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -45,18 +45,18 @@ export class PlayerMonitor {
   /** @type {PlayerMonitorDeps} */
   deps;
 
-  /** @type {number | null} */
+  /** @type {ReturnType<typeof setInterval> | null} */
   monitorTimer;
 
   /** @param {PlayerMonitorDeps} deps */
   constructor(deps) {
     this.deps = deps;
-    this.monitorTimer = /** @type {number | null} */ (null);
+    this.monitorTimer = null;
   }
 
   start() {
     this.stop();
-    this.monitorTimer = window.setInterval(() => {
+    this.monitorTimer = globalThis.setInterval(() => {
       void (async () => {
         try {
           await this.monitorPlayback();

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -10,27 +10,34 @@ import { spotifyStatusMessage } from './spotify-status-message.js';
 
 /**
  * @typedef {{
- *   context: string;
- *   fallbackMessage: string;
- *   authStatusMessage?: string;
- *   playbackStatusMessage?: string;
- *   toastMode?: 'always' | 'cooldown';
- *   toastKey?: string;
- * }} ErrorReportOptions
- */
-
-/**
- * @typedef {{
  *   getSession: () => MonitorSession;
  *   getUsableAccessToken: () => Promise<string | null>;
  *   getPlayerState: () => Promise<{ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string}>;
  *   persistRuntimeState: () => void;
  *   transitionToDetached: (message: string) => void;
  *   goToNextItem: () => Promise<void>;
- *   reportError: (error: unknown, options: ErrorReportOptions) => void;
+ *   reportError: (error: unknown) => void;
  *   isUnrecoverableSpotifyStatus: (status: number) => boolean;
  * }} PlayerMonitorDeps
  */
+
+export class PlayerMonitorStatusError extends Error {
+  /** @type {number} */
+  status;
+
+  /** @type {string} */
+  errorText;
+
+  /**
+   * @param {number} status
+   * @param {string} errorText
+   */
+  constructor(status, errorText) {
+    super(`Playback monitor request failed (${status}): ${errorText}`);
+    this.status = status;
+    this.errorText = errorText;
+  }
+}
 
 export class PlayerMonitor {
   /** @type {PlayerMonitorDeps} */
@@ -52,14 +59,7 @@ export class PlayerMonitor {
         try {
           await this.monitorPlayback();
         } catch (error) {
-          this.deps.reportError(error, {
-            context: 'monitor',
-            fallbackMessage: 'Playback monitor encountered an error.',
-            playbackStatusMessage:
-              'Playback monitor paused due to an error. Try restarting the session.',
-            toastMode: 'cooldown',
-            toastKey: 'monitor-loop',
-          });
+          this.deps.reportError(error);
         }
       })();
     }, 4000);
@@ -91,21 +91,7 @@ export class PlayerMonitor {
         return;
       }
 
-      this.deps.reportError(
-        new Error(
-          `Playback monitor request failed (${playerState.status}): ${playerState.errorText}`,
-        ),
-        {
-          context: 'monitor',
-          fallbackMessage: spotifyStatusMessage(
-            playerState.status,
-            'Could not check playback state.',
-          ),
-          playbackStatusMessage: 'Unable to check playback state right now.',
-          toastMode: 'cooldown',
-          toastKey: `monitor-http-${playerState.status}`,
-        },
-      );
+      this.deps.reportError(new PlayerMonitorStatusError(playerState.status, playerState.errorText));
       return;
     }
 

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -20,7 +20,7 @@ import { spotifyStatusMessage } from './spotify-status-message.js';
  */
 
 /**
- * @param {{
+ * @typedef {{
  *   getSession: () => MonitorSession;
  *   getUsableAccessToken: () => Promise<string | null>;
  *   getPlayerState: () => Promise<{ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string}>;
@@ -29,46 +29,57 @@ import { spotifyStatusMessage } from './spotify-status-message.js';
  *   goToNextItem: () => Promise<void>;
  *   reportError: (error: unknown, options: ErrorReportOptions) => void;
  *   isUnrecoverableSpotifyStatus: (status: number) => boolean;
- * }} deps
+ * }} PlayerMonitorDeps
  */
-export function createPlayerMonitor(deps) {
-  let monitorTimer = /** @type {number | null} */ (null);
 
-  function stop() {
-    if (monitorTimer !== null) {
-      clearInterval(monitorTimer);
-      monitorTimer = null;
-    }
+export class PlayerMonitor {
+  /** @type {PlayerMonitorDeps} */
+  deps;
+
+  /** @type {number | null} */
+  monitorTimer;
+
+  /** @param {PlayerMonitorDeps} deps */
+  constructor(deps) {
+    this.deps = deps;
+    this.monitorTimer = /** @type {number | null} */ (null);
   }
 
-  function start() {
-    stop();
-    monitorTimer = window.setInterval(() => {
-      void monitorPlayback();
+  start() {
+    this.stop();
+    this.monitorTimer = window.setInterval(() => {
+      void this.monitorPlayback();
     }, 4000);
   }
 
-  async function monitorPlayback() {
-    const session = deps.getSession();
+  stop() {
+    if (this.monitorTimer !== null) {
+      clearInterval(this.monitorTimer);
+      this.monitorTimer = null;
+    }
+  }
+
+  async monitorPlayback() {
+    const session = this.deps.getSession();
     if (session.activationState !== 'active' || !session.currentUri) return;
 
-    const token = await deps.getUsableAccessToken();
+    const token = await this.deps.getUsableAccessToken();
     if (!token) {
-      deps.transitionToDetached('Spotify session expired. Please reconnect.');
+      this.deps.transitionToDetached('Spotify session expired. Please reconnect.');
       return;
     }
 
     try {
-      const playerState = await deps.getPlayerState();
+      const playerState = await this.deps.getPlayerState();
       if (!playerState.ok) {
-        if (deps.isUnrecoverableSpotifyStatus(playerState.status)) {
-          deps.transitionToDetached(
+        if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
+          this.deps.transitionToDetached(
             spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'),
           );
           return;
         }
 
-        deps.reportError(
+        this.deps.reportError(
           new Error(
             `Playback monitor request failed (${playerState.status}): ${playerState.errorText}`,
           ),
@@ -90,28 +101,26 @@ export function createPlayerMonitor(deps) {
 
       if (contextUri === session.currentUri) {
         session.observedCurrentContext = true;
-        deps.persistRuntimeState();
+        this.deps.persistRuntimeState();
         return;
       }
 
       if (!session.observedCurrentContext) {
-        // Ignore transient mismatch while a new context is still starting.
         return;
       }
 
       if (session.observedCurrentContext && contextUri === null) {
-        // Current context is no longer active (likely finished).
-        await deps.goToNextItem();
+        await this.deps.goToNextItem();
         return;
       }
 
       if (contextUri && contextUri !== session.currentUri) {
-        deps.transitionToDetached(
+        this.deps.transitionToDetached(
           'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
         );
       }
     } catch (error) {
-      deps.reportError(error, {
+      this.deps.reportError(error, {
         context: 'monitor',
         fallbackMessage: 'Playback monitor encountered an error.',
         playbackStatusMessage:
@@ -121,6 +130,4 @@ export function createPlayerMonitor(deps) {
       });
     }
   }
-
-  return { start, stop };
 }

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -1,0 +1,126 @@
+import { spotifyStatusMessage } from './spotify-status-message.js';
+
+/**
+ * @typedef {{
+ *   activationState: 'inactive' | 'active' | 'detached';
+ *   currentUri: string | null;
+ *   observedCurrentContext: boolean;
+ * }} MonitorSession
+ */
+
+/**
+ * @typedef {{
+ *   context: string;
+ *   fallbackMessage: string;
+ *   authStatusMessage?: string;
+ *   playbackStatusMessage?: string;
+ *   toastMode?: 'always' | 'cooldown';
+ *   toastKey?: string;
+ * }} ErrorReportOptions
+ */
+
+/**
+ * @param {{
+ *   getSession: () => MonitorSession;
+ *   getUsableAccessToken: () => Promise<string | null>;
+ *   getPlayerState: () => Promise<{ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string}>;
+ *   persistRuntimeState: () => void;
+ *   transitionToDetached: (message: string) => void;
+ *   goToNextItem: () => Promise<void>;
+ *   reportError: (error: unknown, options: ErrorReportOptions) => void;
+ *   isUnrecoverableSpotifyStatus: (status: number) => boolean;
+ * }} deps
+ */
+export function createPlayerMonitor(deps) {
+  let monitorTimer = /** @type {number | null} */ (null);
+
+  function stop() {
+    if (monitorTimer !== null) {
+      clearInterval(monitorTimer);
+      monitorTimer = null;
+    }
+  }
+
+  function start() {
+    stop();
+    monitorTimer = window.setInterval(() => {
+      void monitorPlayback();
+    }, 4000);
+  }
+
+  async function monitorPlayback() {
+    const session = deps.getSession();
+    if (session.activationState !== 'active' || !session.currentUri) return;
+
+    const token = await deps.getUsableAccessToken();
+    if (!token) {
+      deps.transitionToDetached('Spotify session expired. Please reconnect.');
+      return;
+    }
+
+    try {
+      const playerState = await deps.getPlayerState();
+      if (!playerState.ok) {
+        if (deps.isUnrecoverableSpotifyStatus(playerState.status)) {
+          deps.transitionToDetached(
+            spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'),
+          );
+          return;
+        }
+
+        deps.reportError(
+          new Error(
+            `Playback monitor request failed (${playerState.status}): ${playerState.errorText}`,
+          ),
+          {
+            context: 'monitor',
+            fallbackMessage: spotifyStatusMessage(
+              playerState.status,
+              'Could not check playback state.',
+            ),
+            playbackStatusMessage: 'Unable to check playback state right now.',
+            toastMode: 'cooldown',
+            toastKey: `monitor-http-${playerState.status}`,
+          },
+        );
+        return;
+      }
+
+      const contextUri = playerState.contextUri;
+
+      if (contextUri === session.currentUri) {
+        session.observedCurrentContext = true;
+        deps.persistRuntimeState();
+        return;
+      }
+
+      if (!session.observedCurrentContext) {
+        // Ignore transient mismatch while a new context is still starting.
+        return;
+      }
+
+      if (session.observedCurrentContext && contextUri === null) {
+        // Current context is no longer active (likely finished).
+        await deps.goToNextItem();
+        return;
+      }
+
+      if (contextUri && contextUri !== session.currentUri) {
+        deps.transitionToDetached(
+          'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
+        );
+      }
+    } catch (error) {
+      deps.reportError(error, {
+        context: 'monitor',
+        fallbackMessage: 'Playback monitor encountered an error.',
+        playbackStatusMessage:
+          'Playback monitor paused due to an error. Try restarting the session.',
+        toastMode: 'cooldown',
+        toastKey: 'monitor-loop',
+      });
+    }
+  }
+
+  return { start, stop };
+}

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -1,5 +1,7 @@
 import { spotifyStatusMessage } from './spotify-status-message.js';
 
+/** @typedef {import('./spotify-app-api.js').SpotifyAppApi} SpotifyAppApi */
+
 /**
  * @typedef {{
  *   activationState: 'inactive' | 'active' | 'detached';
@@ -12,7 +14,7 @@ import { spotifyStatusMessage } from './spotify-status-message.js';
  * @typedef {{
  *   getSession: () => MonitorSession;
  *   getUsableAccessToken: () => Promise<string | null>;
- *   getPlayerState: () => Promise<{ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string}>;
+ *   spotifyAppApi: SpotifyAppApi;
  *   persistRuntimeState: () => void;
  *   transitionToDetached: (message: string) => void;
  *   goToNextItem: () => Promise<void>;
@@ -82,7 +84,7 @@ export class PlayerMonitor {
       return;
     }
 
-    const playerState = await this.deps.getPlayerState();
+    const playerState = await this.deps.spotifyAppApi.getPlayerState();
     if (!playerState.ok) {
       if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
         this.deps.transitionToDetached(

--- a/tests/player-monitor.test.js
+++ b/tests/player-monitor.test.js
@@ -1,0 +1,144 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PlayerMonitor, PlayerMonitorStatusError } from '../src/player-monitor.js';
+
+/** @typedef {import('../src/player-monitor.js').PlayerMonitorDeps} PlayerMonitorDeps */
+
+/**
+ * @param {{
+ *   activationState?: 'inactive' | 'active' | 'detached';
+ *   currentUri?: string | null;
+ *   observedCurrentContext?: boolean;
+ *   token?: string | null;
+ *   playerState?: {ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string};
+ *   playerStateError?: Error;
+ *   isUnrecoverable?: (status: number) => boolean;
+ * }} [options]
+ */
+function createMonitor(options = {}) {
+  const session = {
+    activationState: options.activationState ?? 'active',
+    currentUri: options.currentUri ?? 'spotify:album:current',
+    observedCurrentContext: options.observedCurrentContext ?? false,
+  };
+
+  const detachedMessages = /** @type {string[]} */ ([]);
+  const reportedErrors = /** @type {unknown[]} */ ([]);
+
+  const persistRuntimeState = mock.fn();
+  const transitionToDetached = mock.fn((/** @type {string} */ message) => {
+    detachedMessages.push(message);
+  });
+  const goToNextItem = mock.fn(async () => {});
+  const reportError = mock.fn((/** @type {unknown} */ error) => {
+    reportedErrors.push(error);
+  });
+  const getUsableAccessToken = mock.fn(async () => (options.token === undefined ? 'token' : options.token));
+  const getPlayerState = mock.fn(async () => {
+    if (options.playerStateError) {
+      throw options.playerStateError;
+    }
+    return options.playerState ?? { ok: true, contextUri: session.currentUri };
+  });
+
+  const deps = /** @type {PlayerMonitorDeps} */ ({
+    getSession: () => session,
+    getUsableAccessToken,
+    spotifyAppApi: /** @type {import('../src/spotify-app-api.js').SpotifyAppApi} */ (
+      /** @type {unknown} */ ({ getPlayerState })
+    ),
+    persistRuntimeState,
+    transitionToDetached,
+    goToNextItem,
+    reportError,
+    isUnrecoverableSpotifyStatus: options.isUnrecoverable ?? ((status) => status === 401),
+  });
+
+  return {
+    session,
+    monitor: new PlayerMonitor(deps),
+    detachedMessages,
+    reportedErrors,
+    spies: {
+      persistRuntimeState,
+      transitionToDetached,
+      goToNextItem,
+      reportError,
+      getUsableAccessToken,
+      getPlayerState,
+    },
+  };
+}
+
+test('monitorPlayback marks context as observed and persists when player context matches current uri', async () => {
+  const { session, monitor, spies } = createMonitor();
+
+  await monitor.monitorPlayback();
+
+  assert.equal(session.observedCurrentContext, true);
+  assert.equal(spies.persistRuntimeState.mock.callCount(), 1);
+  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
+});
+
+test('monitorPlayback detaches when token is unavailable', async () => {
+  const { monitor, detachedMessages, spies } = createMonitor({ token: null });
+
+  await monitor.monitorPlayback();
+
+  assert.deepEqual(detachedMessages, ['Spotify session expired. Please reconnect.']);
+  assert.equal(spies.getPlayerState.mock.callCount(), 0);
+});
+
+test('monitorPlayback reports recoverable player-state status errors', async () => {
+  const { monitor, reportedErrors } = createMonitor({
+    playerState: { ok: false, status: 429, errorText: 'slow down' },
+    isUnrecoverable: () => false,
+  });
+
+  await monitor.monitorPlayback();
+
+  assert.equal(reportedErrors.length, 1);
+  assert.ok(reportedErrors[0] instanceof PlayerMonitorStatusError);
+  const playerMonitorError = /** @type {PlayerMonitorStatusError} */ (reportedErrors[0]);
+  assert.equal(playerMonitorError.status, 429);
+  assert.equal(playerMonitorError.errorText, 'slow down');
+});
+
+test('monitorPlayback advances when observed context becomes null', async () => {
+  const { monitor, spies } = createMonitor({
+    observedCurrentContext: true,
+    playerState: { ok: true, contextUri: null },
+  });
+
+  await monitor.monitorPlayback();
+
+  assert.equal(spies.goToNextItem.mock.callCount(), 1);
+  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
+});
+
+test('start catches monitor loop errors and forwards them to reportError', async () => {
+  /** @type {() => void} */
+  let intervalCallback = () => {};
+
+  const setIntervalMock = mock.method(
+    globalThis,
+    'setInterval',
+    /** @param {() => void} callback */
+    (callback) => {
+      intervalCallback = callback;
+      return /** @type {ReturnType<typeof setInterval>} */ (/** @type {unknown} */ (17));
+    },
+  );
+
+  const { monitor, reportedErrors } = createMonitor({ playerStateError: new Error('boom') });
+
+  monitor.start();
+  assert.equal(setIntervalMock.mock.callCount(), 1);
+  intervalCallback();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(reportedErrors.length, 1);
+  assert.ok(reportedErrors[0] instanceof Error);
+  assert.match((/** @type {Error} */ (reportedErrors[0])).message, /boom/);
+});


### PR DESCRIPTION
### Motivation
- Separate the playback-monitor polling and interval lifecycle from the main app to improve modularity and testability.
- Make it easier to reuse and reason about the monitor logic without cluttering `src/app.js`.

### Description
- Added a new module `src/player-monitor.js` that exports `createPlayerMonitor`, which owns the monitor interval and playback-state polling and exposes `start`/`stop` methods.
- Updated `src/app.js` to import `createPlayerMonitor`, instantiate `playerMonitor` with the required app dependencies (`getSession`, `getUsableAccessToken`, `getPlayerState`, `persistRuntimeState`, `transitionToDetached`, `goToNextItem`, `reportError`, `isUnrecoverableSpotifyStatus`), and wire `playerMonitor.start()` / `playerMonitor.stop()` into session lifecycle flows.
- Removed the inline `monitorTimer`, `startMonitorLoop`, `stopMonitorLoop`, and `monitorPlayback` logic from `src/app.js` and replaced their usages with the `playerMonitor` instance to preserve existing behavior.

### Testing
- Ran `npm run check`, which executes the test suite, and the run completed successfully with all tests passing (`15` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd572e147c8321b6b36905994990ce)