### PR TITLE
Prevent force-push workflow from running on test branch

### DIFF
--- a/.github/workflows/force-push-test.yml
+++ b/.github/workflows/force-push-test.yml
@@ -2,8 +2,8 @@ name: Force Push to `test`
 
 on:
   push:
-    branches:
-      - '**'
+    branches-ignore:
+      - test
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation
- Prevent the "Force Push to `test`" GitHub Actions from retriggering itself when it force-pushes to the `test` branch.

### Description
- Update `.github/workflows/force-push-test.yml` to replace the broad `push` branch match with `branches-ignore: - test` while keeping `workflow_dispatch` so the job can still be run manually.

### Testing
- Ran `npm run check` and the test suite completed successfully with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dedf2604348321ac7a97d6fcf172f5)