### PR TITLE
refactor: use private class members for internal-only state

### DIFF
--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -1,4 +1,6 @@
 export class AuthFlow {
+  /** @type {{scopes: string[]; spotifyAppId: string; storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; }; reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void; setAuthStatus: (message: string) => void;}} */
+  #deps;
   /**
    * @param {{
    *  scopes: string[];
@@ -9,8 +11,7 @@ export class AuthFlow {
    * }} deps
    */
   constructor(deps) {
-    /** @type {{scopes: string[]; spotifyAppId: string; storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; }; reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void; setAuthStatus: (message: string) => void;}} */
-    this.deps = deps;
+    this.#deps = deps;
   }
 
   async startLogin() {
@@ -19,12 +20,12 @@ export class AuthFlow {
     );
     const verifier = randomString(64);
     const challenge = await codeChallengeFromVerifier(verifier);
-    localStorage.setItem(this.deps.storageKeys.verifier, verifier);
+    localStorage.setItem(this.#deps.storageKeys.verifier, verifier);
 
     const params = new URLSearchParams({
       response_type: 'code',
-      client_id: this.deps.spotifyAppId,
-      scope: this.deps.scopes.join(' '),
+      client_id: this.#deps.spotifyAppId,
+      scope: this.#deps.scopes.join(' '),
       redirect_uri: locationRef.origin + locationRef.pathname,
       code_challenge_method: 'S256',
       code_challenge: challenge,
@@ -46,7 +47,7 @@ export class AuthFlow {
     const error = url.searchParams.get('error');
 
     if (error) {
-      this.deps.setAuthStatus(`Spotify authorization error: ${error}`);
+      this.#deps.setAuthStatus(`Spotify authorization error: ${error}`);
       url.searchParams.delete('error');
       historyRef.replaceState({}, '', url.toString());
       return;
@@ -54,10 +55,10 @@ export class AuthFlow {
 
     if (!code) return;
 
-    const verifier = localStorage.getItem(this.deps.storageKeys.verifier);
+    const verifier = localStorage.getItem(this.#deps.storageKeys.verifier);
 
     if (!verifier) {
-      this.deps.setAuthStatus('Missing PKCE verifier. Try connecting again.');
+      this.#deps.setAuthStatus('Missing PKCE verifier. Try connecting again.');
       return;
     }
 
@@ -65,7 +66,7 @@ export class AuthFlow {
       grant_type: 'authorization_code',
       code,
       redirect_uri: locationRef.origin + locationRef.pathname,
-      client_id: this.deps.spotifyAppId,
+      client_id: this.#deps.spotifyAppId,
       code_verifier: verifier,
     });
 
@@ -76,35 +77,35 @@ export class AuthFlow {
     });
 
     if (!response.ok) {
-      this.deps.setAuthStatus('Failed to exchange Spotify code for token.');
+      this.#deps.setAuthStatus('Failed to exchange Spotify code for token.');
       return;
     }
 
     /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */
     const data = /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */ (await response.json());
-    localStorage.setItem(this.deps.storageKeys.token, data.access_token);
+    localStorage.setItem(this.#deps.storageKeys.token, data.access_token);
     if (data.refresh_token) {
-      localStorage.setItem(this.deps.storageKeys.refreshToken, data.refresh_token);
+      localStorage.setItem(this.#deps.storageKeys.refreshToken, data.refresh_token);
     }
-    localStorage.setItem(this.deps.storageKeys.tokenExpiry, String(Date.now() + data.expires_in * 1000));
-    localStorage.setItem(this.deps.storageKeys.tokenScope, data.scope ?? '');
-    localStorage.removeItem(this.deps.storageKeys.verifier);
+    localStorage.setItem(this.#deps.storageKeys.tokenExpiry, String(Date.now() + data.expires_in * 1000));
+    localStorage.setItem(this.#deps.storageKeys.tokenScope, data.scope ?? '');
+    localStorage.removeItem(this.#deps.storageKeys.verifier);
 
     url.searchParams.delete('code');
     historyRef.replaceState({}, '', url.toString());
   }
 
   clearAuth() {
-    localStorage.removeItem(this.deps.storageKeys.token);
-    localStorage.removeItem(this.deps.storageKeys.refreshToken);
-    localStorage.removeItem(this.deps.storageKeys.tokenExpiry);
-    localStorage.removeItem(this.deps.storageKeys.tokenScope);
-    localStorage.removeItem(this.deps.storageKeys.verifier);
+    localStorage.removeItem(this.#deps.storageKeys.token);
+    localStorage.removeItem(this.#deps.storageKeys.refreshToken);
+    localStorage.removeItem(this.#deps.storageKeys.tokenExpiry);
+    localStorage.removeItem(this.#deps.storageKeys.tokenScope);
+    localStorage.removeItem(this.#deps.storageKeys.verifier);
   }
 
   getToken() {
-    const token = localStorage.getItem(this.deps.storageKeys.token);
-    const expiryMs = Number(localStorage.getItem(this.deps.storageKeys.tokenExpiry) ?? 0);
+    const token = localStorage.getItem(this.#deps.storageKeys.token);
+    const expiryMs = Number(localStorage.getItem(this.#deps.storageKeys.tokenExpiry) ?? 0);
     if (!token || Date.now() >= expiryMs) {
       return null;
     }
@@ -112,18 +113,18 @@ export class AuthFlow {
   }
 
   getGrantedScopes() {
-    const scopeText = localStorage.getItem(this.deps.storageKeys.tokenScope) ?? '';
+    const scopeText = localStorage.getItem(this.#deps.storageKeys.tokenScope) ?? '';
     return new Set(scopeText.split(/\s+/).filter(Boolean));
   }
 
   async refreshSpotifyAccessToken() {
-    const refreshToken = localStorage.getItem(this.deps.storageKeys.refreshToken);
+    const refreshToken = localStorage.getItem(this.#deps.storageKeys.refreshToken);
     if (!refreshToken) return null;
 
     const formData = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
-      client_id: this.deps.spotifyAppId,
+      client_id: this.#deps.spotifyAppId,
     });
 
     /** @type {Response} */
@@ -135,7 +136,7 @@ export class AuthFlow {
         body: formData,
       });
     } catch (error) {
-      this.deps.reportError(error, {
+      this.#deps.reportError(error, {
         context: 'auth',
         fallbackMessage: 'Unable to refresh Spotify session.',
         authStatusMessage: 'Network issue refreshing Spotify session. Please reconnect if this continues.',
@@ -149,13 +150,13 @@ export class AuthFlow {
 
     /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */
     const data = /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */ (await response.json());
-    localStorage.setItem(this.deps.storageKeys.token, data.access_token);
-    localStorage.setItem(this.deps.storageKeys.tokenExpiry, String(Date.now() + data.expires_in * 1000));
+    localStorage.setItem(this.#deps.storageKeys.token, data.access_token);
+    localStorage.setItem(this.#deps.storageKeys.tokenExpiry, String(Date.now() + data.expires_in * 1000));
     if (typeof data.scope === 'string') {
-      localStorage.setItem(this.deps.storageKeys.tokenScope, data.scope);
+      localStorage.setItem(this.#deps.storageKeys.tokenScope, data.scope);
     }
     if (data.refresh_token) {
-      localStorage.setItem(this.deps.storageKeys.refreshToken, data.refresh_token);
+      localStorage.setItem(this.#deps.storageKeys.refreshToken, data.refresh_token);
     }
     return data.access_token;
   }
@@ -164,7 +165,7 @@ export class AuthFlow {
     const token = this.getToken();
     if (token) return token;
 
-    const hasRefreshToken = Boolean(localStorage.getItem(this.deps.storageKeys.refreshToken));
+    const hasRefreshToken = Boolean(localStorage.getItem(this.#deps.storageKeys.refreshToken));
     if (!hasRefreshToken) return null;
 
     return this.refreshSpotifyAccessToken();

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -1,15 +1,17 @@
+/**
+ * @typedef {{
+ *  scopes: string[];
+ *  spotifyAppId: string;
+ *  storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; };
+ *  reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void;
+ *  setAuthStatus: (message: string) => void;
+ * }} AuthFlowDeps
+ */
+
 export class AuthFlow {
-  /** @type {{scopes: string[]; spotifyAppId: string; storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; }; reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void; setAuthStatus: (message: string) => void;}} */
+  /** @type {AuthFlowDeps} */
   #deps;
-  /**
-   * @param {{
-   *  scopes: string[];
-   *  spotifyAppId: string;
-   *  storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; };
-   *  reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void;
-   *  setAuthStatus: (message: string) => void;
-   * }} deps
-   */
+  /** @param {AuthFlowDeps} deps */
   constructor(deps) {
     this.#deps = deps;
   }

--- a/src/core/error-reporter.js
+++ b/src/core/error-reporter.js
@@ -1,6 +1,10 @@
 const ERROR_TOAST_COOLDOWN_MS = 45000;
 
 export class ErrorReporter {
+  /** @type {{setAuthStatus: (message: string) => void; setPlaybackStatus: (message: string) => void; showToast: (message: string, type?: 'success' | 'info' | 'error') => void;}} */
+  #deps;
+  /** @type {Map<string, number>} */
+  #errorToastLastShownAt;
   /**
    * @param {{
    *  setAuthStatus: (message: string) => void;
@@ -9,10 +13,8 @@ export class ErrorReporter {
    * }} deps
    */
   constructor(deps) {
-    /** @type {{setAuthStatus: (message: string) => void; setPlaybackStatus: (message: string) => void; showToast: (message: string, type?: 'success' | 'info' | 'error') => void;}} */
-    this.deps = deps;
-    /** @type {Map<string, number>} */
-    this.errorToastLastShownAt = new Map();
+    this.#deps = deps;
+    this.#errorToastLastShownAt = new Map();
   }
 
   /**
@@ -39,23 +41,23 @@ export class ErrorReporter {
     console.error(`[${options.context}]`, error);
 
     if (options.authStatusMessage) {
-      this.deps.setAuthStatus(options.authStatusMessage);
+      this.#deps.setAuthStatus(options.authStatusMessage);
     }
     if (options.playbackStatusMessage) {
-      this.deps.setPlaybackStatus(options.playbackStatusMessage);
+      this.#deps.setPlaybackStatus(options.playbackStatusMessage);
     }
 
     const toastKey = options.toastKey ?? `${options.context}:${message}`;
     if (options.toastMode === 'cooldown') {
-      const lastAt = this.errorToastLastShownAt.get(toastKey) ?? 0;
+      const lastAt = this.#errorToastLastShownAt.get(toastKey) ?? 0;
       if (Date.now() - lastAt >= ERROR_TOAST_COOLDOWN_MS) {
-        this.errorToastLastShownAt.set(toastKey, Date.now());
-        this.deps.showToast(message, 'error');
+        this.#errorToastLastShownAt.set(toastKey, Date.now());
+        this.#deps.showToast(message, 'error');
       }
       return;
     }
 
-    this.deps.showToast(message, 'error');
+    this.#deps.showToast(message, 'error');
   }
 }
 

--- a/src/core/error-reporter.js
+++ b/src/core/error-reporter.js
@@ -1,17 +1,12 @@
 const ERROR_TOAST_COOLDOWN_MS = 45000;
+/** @typedef {{setAuthStatus: (message: string) => void; setPlaybackStatus: (message: string) => void; showToast: (message: string, type?: 'success' | 'info' | 'error') => void;}} ErrorReporterDeps */
 
 export class ErrorReporter {
-  /** @type {{setAuthStatus: (message: string) => void; setPlaybackStatus: (message: string) => void; showToast: (message: string, type?: 'success' | 'info' | 'error') => void;}} */
+  /** @type {ErrorReporterDeps} */
   #deps;
   /** @type {Map<string, number>} */
   #errorToastLastShownAt;
-  /**
-   * @param {{
-   *  setAuthStatus: (message: string) => void;
-   *  setPlaybackStatus: (message: string) => void;
-   *  showToast: (message: string, type?: 'success' | 'info' | 'error') => void;
-   * }} deps
-   */
+  /** @param {ErrorReporterDeps} deps */
   constructor(deps) {
     this.#deps = deps;
     this.#errorToastLastShownAt = new Map();

--- a/src/core/item-store.js
+++ b/src/core/item-store.js
@@ -2,12 +2,13 @@ import { exportItemsData, importItemsData } from './storage-transfer.js';
 
 /** @typedef {'album' | 'playlist'} ItemType */
 /** @typedef {{uri: string; type: ItemType; title: string}} ShuffleItem */
+/** @typedef {{ items: string }} ItemStoreStorageKeys */
 
 export class ItemStore {
-  /** @type {{ items: string }} */
+  /** @type {ItemStoreStorageKeys} */
   #storageKeys;
 
-  /** @param {{ items: string }} storageKeys */
+  /** @param {ItemStoreStorageKeys} storageKeys */
   constructor(storageKeys) {
     this.#storageKeys = storageKeys;
   }

--- a/src/core/item-store.js
+++ b/src/core/item-store.js
@@ -4,15 +4,17 @@ import { exportItemsData, importItemsData } from './storage-transfer.js';
 /** @typedef {{uri: string; type: ItemType; title: string}} ShuffleItem */
 
 export class ItemStore {
+  /** @type {{ items: string }} */
+  #storageKeys;
+
   /** @param {{ items: string }} storageKeys */
   constructor(storageKeys) {
-    /** @type {{ items: string }} */
-    this.storageKeys = storageKeys;
+    this.#storageKeys = storageKeys;
   }
 
   /** @returns {ShuffleItem[]} */
   getItems() {
-    const raw = localStorage.getItem(this.storageKeys.items);
+    const raw = localStorage.getItem(this.#storageKeys.items);
     if (!raw) return [];
 
     try {
@@ -27,13 +29,13 @@ export class ItemStore {
 
   /** @param {ShuffleItem[]} items */
   saveItems(items) {
-    localStorage.setItem(this.storageKeys.items, JSON.stringify(items));
+    localStorage.setItem(this.#storageKeys.items, JSON.stringify(items));
   }
 
   /** @returns {{ data: Record<string, unknown> | null; error: string | null }} */
   exportData() {
-    const rawItems = localStorage.getItem(this.storageKeys.items);
-    return exportItemsData(rawItems, this.storageKeys.items);
+    const rawItems = localStorage.getItem(this.#storageKeys.items);
+    return exportItemsData(rawItems, this.#storageKeys.items);
   }
 
   /**
@@ -41,7 +43,7 @@ export class ItemStore {
    * @returns {{ ok: false; error: string } | { ok: true; items: ShuffleItem[] }}
    */
   importFromJson(raw) {
-    const parsed = importItemsData(raw, this.storageKeys.items);
+    const parsed = importItemsData(raw, this.#storageKeys.items);
     if (!parsed.ok) return parsed;
     const items = normalizeItems(parsed.items);
     this.saveItems(items);

--- a/src/core/session-controller.js
+++ b/src/core/session-controller.js
@@ -21,14 +21,18 @@
  */
 
 export class SessionController {
+  /** @type {SessionControllerDeps} */
+  #deps;
+  /** @type {{start: () => void; stop: () => void} | null} */
+  #playerMonitor;
+  /** @type {SessionState} */
+  #session;
+
   /** @param {SessionControllerDeps} deps */
   constructor(deps) {
-    /** @type {SessionControllerDeps} */
-    this.deps = deps;
-    /** @type {{start: () => void; stop: () => void} | null} */
-    this.playerMonitor = null;
-    /** @type {SessionState} */
-    this.session = {
+    this.#deps = deps;
+    this.#playerMonitor = null;
+    this.#session = {
       activationState: 'inactive',
       queue: [],
       index: 0,
@@ -39,37 +43,37 @@ export class SessionController {
 
   /** @param {{start: () => void; stop: () => void}} monitor */
   setPlayerMonitor(monitor) {
-    this.playerMonitor = monitor;
+    this.#playerMonitor = monitor;
   }
 
   /** @returns {SessionState} */
   getSession() {
-    return this.session;
+    return this.#session;
   }
 
   async startShuffleSession() {
-    const token = await this.deps.getUsableAccessToken();
+    const token = await this.#deps.getUsableAccessToken();
     if (!token) {
-      this.deps.showToast('Connect Spotify first.', 'error');
+      this.#deps.showToast('Connect Spotify first.', 'error');
       return;
     }
 
-    const items = this.deps.getItems();
+    const items = this.#deps.getItems();
     if (items.length === 0) {
-      this.deps.showToast('Add at least one album or playlist first.', 'info');
+      this.#deps.showToast('Add at least one album or playlist first.', 'info');
       return;
     }
 
-    this.session.queue = this.deps.shuffledCopy(items);
-    this.session.activationState = 'active';
-    this.session.index = 0;
+    this.#session.queue = this.#deps.shuffledCopy(items);
+    this.#session.activationState = 'active';
+    this.#session.index = 0;
     this.persistRuntimeState();
-    this.render();
+    this.#render();
 
-    this.deps.setPlaybackStatus(`Session started with ${this.session.queue.length} item(s).`);
+    this.#deps.setPlaybackStatus(`Session started with ${this.#session.queue.length} item(s).`);
     await this.playCurrentItem();
-    if (this.session.activationState === 'active') {
-      this.playerMonitor?.start();
+    if (this.#session.activationState === 'active') {
+      this.#playerMonitor?.start();
     }
   }
 
@@ -80,66 +84,66 @@ export class SessionController {
 
   /** @param {string} message */
   transitionToInactive(message) {
-    this.playerMonitor?.stop();
-    this.session.activationState = 'inactive';
-    this.session.queue = [];
-    this.session.index = 0;
-    this.session.currentUri = null;
-    this.session.observedCurrentContext = false;
+    this.#playerMonitor?.stop();
+    this.#session.activationState = 'inactive';
+    this.#session.queue = [];
+    this.#session.index = 0;
+    this.#session.currentUri = null;
+    this.#session.observedCurrentContext = false;
     this.clearRuntimeState();
-    this.render();
-    this.deps.setPlaybackStatus(message);
+    this.#render();
+    this.#deps.setPlaybackStatus(message);
   }
 
   /** @param {string} message */
   transitionToDetached(message) {
-    if (this.session.activationState === 'inactive') {
+    if (this.#session.activationState === 'inactive') {
       return;
     }
-    this.playerMonitor?.stop();
-    this.session.activationState = 'detached';
+    this.#playerMonitor?.stop();
+    this.#session.activationState = 'detached';
     this.persistRuntimeState();
-    this.render();
-    this.deps.setPlaybackStatus(message);
+    this.#render();
+    this.#deps.setPlaybackStatus(message);
   }
 
   async goToNextItem() {
-    if (this.session.activationState !== 'active') {
-      this.deps.setPlaybackStatus('No active session.');
+    if (this.#session.activationState !== 'active') {
+      this.#deps.setPlaybackStatus('No active session.');
       return;
     }
 
-    this.session.index += 1;
+    this.#session.index += 1;
     this.persistRuntimeState();
-    if (this.session.index >= this.session.queue.length) {
+    if (this.#session.index >= this.#session.queue.length) {
       this.stopSession('Finished: all selected albums/playlists were played.');
       return;
     }
-    this.deps.renderSessionQueue(this.session);
+    this.#deps.renderSessionQueue(this.#session);
 
     await this.playCurrentItem();
   }
 
   async reattachSession() {
-    if (this.session.activationState !== 'detached') {
+    if (this.#session.activationState !== 'detached') {
       return;
     }
-    const current = this.session.queue[this.session.index];
+    const current = this.#session.queue[this.#session.index];
     if (!current) {
       this.transitionToInactive('No queued item available to reattach.');
       return;
     }
 
-    const token = await this.deps.getUsableAccessToken();
+    const token = await this.#deps.getUsableAccessToken();
     if (!token) {
       this.transitionToDetached('Spotify session expired. Please reconnect.');
       return;
     }
 
-    const playerState = await this.deps.spotifyAppApi.getPlayerState();
+    const playerState = await this.#deps.spotifyAppApi.getPlayerState();
     if (!playerState.ok) {
-      if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
-        this.transitionToDetached(this.deps.spotifyStatusMessage(playerState.status, 'Unable to reattach playback state.'));
+      if (this.#deps.isUnrecoverableSpotifyStatus(playerState.status)) {
+        this.transitionToDetached(this.#deps.spotifyStatusMessage(playerState.status, 'Unable to reattach playback state.'));
         return;
       }
       throw new Error(
@@ -150,50 +154,50 @@ export class SessionController {
     const contextUri = playerState.contextUri;
 
     if (contextUri !== current.uri) {
-      this.session.activationState = 'active';
+      this.#session.activationState = 'active';
       await this.playCurrentItem();
     } else {
-      this.session.currentUri = current.uri;
-      this.session.observedCurrentContext = true;
-      this.session.activationState = 'active';
+      this.#session.currentUri = current.uri;
+      this.#session.observedCurrentContext = true;
+      this.#session.activationState = 'active';
       this.persistRuntimeState();
-      this.render();
-      this.deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
+      this.#render();
+      this.#deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
     }
-    if (this.session.activationState === 'active') {
-      this.playerMonitor?.start();
+    if (this.#session.activationState === 'active') {
+      this.#playerMonitor?.start();
     }
   }
 
   async playCurrentItem() {
-    const current = this.session.queue[this.session.index];
+    const current = this.#session.queue[this.#session.index];
     if (!current) {
       this.transitionToInactive('Finished: all selected albums/playlists were played.');
       return;
     }
-    this.session.currentUri = current.uri;
-    this.session.observedCurrentContext = false;
-    this.session.activationState = 'active';
+    this.#session.currentUri = current.uri;
+    this.#session.observedCurrentContext = false;
+    this.#session.activationState = 'active';
     this.persistRuntimeState();
-    this.render();
+    this.#render();
 
-    const token = await this.deps.getUsableAccessToken();
+    const token = await this.#deps.getUsableAccessToken();
     if (!token) {
       this.stopSession('Spotify session expired. Please reconnect.');
       return;
     }
 
     try {
-      await this.deps.spotifyAppApi.disableShuffle();
-      await this.deps.spotifyAppApi.disableRepeat();
-      await this.deps.spotifyAppApi.playContext(current.uri);
+      await this.#deps.spotifyAppApi.disableShuffle();
+      await this.#deps.spotifyAppApi.disableRepeat();
+      await this.#deps.spotifyAppApi.playContext(current.uri);
     } catch (error) {
-      this.deps.reportError(error, {
+      this.#deps.reportError(error, {
         context: 'playback',
         fallbackMessage: 'Unable to start playback on Spotify.',
         playbackStatusMessage: 'Could not start playback. Ensure an active Spotify device is available.',
       });
-      if (this.deps.isUnrecoverableSpotifyError(error)) {
+      if (this.#deps.isUnrecoverableSpotifyError(error)) {
         this.transitionToDetached('Playback detached due to a Spotify error. Reattach when ready.');
         return;
       }
@@ -201,11 +205,11 @@ export class SessionController {
       return;
     }
 
-    this.deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
+    this.#deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
   }
 
   restoreRuntimeState() {
-    const raw = localStorage.getItem(this.deps.runtimeStorageKey);
+    const raw = localStorage.getItem(this.#deps.runtimeStorageKey);
     if (!raw) return;
 
     /** @type {unknown} */
@@ -213,12 +217,12 @@ export class SessionController {
     try {
       parsedUnknown = JSON.parse(raw);
     } catch {
-      localStorage.removeItem(this.deps.runtimeStorageKey);
+      localStorage.removeItem(this.#deps.runtimeStorageKey);
       return;
     }
 
     if (!parsedUnknown || typeof parsedUnknown !== 'object' || Array.isArray(parsedUnknown)) {
-      localStorage.removeItem(this.deps.runtimeStorageKey);
+      localStorage.removeItem(this.#deps.runtimeStorageKey);
       return;
     }
     const parsed = /** @type {Record<string, unknown>} */ (parsedUnknown);
@@ -262,51 +266,51 @@ export class SessionController {
       restoredActivationState = 'inactive';
     }
 
-    this.session.queue = restoredQueue;
-    this.session.index = Math.min(restoredIndex, Math.max(0, restoredQueue.length - 1));
-    this.session.currentUri = restoredCurrentUri;
-    this.session.observedCurrentContext = restoredObserved;
-    this.session.activationState = restoredActivationState;
+    this.#session.queue = restoredQueue;
+    this.#session.index = Math.min(restoredIndex, Math.max(0, restoredQueue.length - 1));
+    this.#session.currentUri = restoredCurrentUri;
+    this.#session.observedCurrentContext = restoredObserved;
+    this.#session.activationState = restoredActivationState;
 
-    if (this.session.activationState === 'inactive') {
+    if (this.#session.activationState === 'inactive') {
       this.clearRuntimeState();
       return;
     }
 
-    const current = this.session.queue[this.session.index];
-    this.deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
-    this.render();
-    if (this.session.activationState === 'active') {
-      this.playerMonitor?.start();
+    const current = this.#session.queue[this.#session.index];
+    this.#deps.setPlaybackStatus(this.formatNowPlayingStatus(current));
+    this.#render();
+    if (this.#session.activationState === 'active') {
+      this.#playerMonitor?.start();
     }
   }
 
   persistRuntimeState() {
     localStorage.setItem(
-      this.deps.runtimeStorageKey,
+      this.#deps.runtimeStorageKey,
       JSON.stringify({
-        active: this.session.activationState === 'active',
-        activationState: this.session.activationState,
-        queue: this.session.queue,
-        index: this.session.index,
-        currentUri: this.session.currentUri,
-        observedCurrentContext: this.session.observedCurrentContext,
+        active: this.#session.activationState === 'active',
+        activationState: this.#session.activationState,
+        queue: this.#session.queue,
+        index: this.#session.index,
+        currentUri: this.#session.currentUri,
+        observedCurrentContext: this.#session.observedCurrentContext,
       }),
     );
   }
 
   clearRuntimeState() {
-    localStorage.removeItem(this.deps.runtimeStorageKey);
+    localStorage.removeItem(this.#deps.runtimeStorageKey);
   }
 
   /** @param {ShuffleItem} item */
   formatNowPlayingStatus(item) {
-    return `Now playing ${item.type} ${this.session.index + 1} of ${this.session.queue.length}: ${item.title}`;
+    return `Now playing ${item.type} ${this.#session.index + 1} of ${this.#session.queue.length}: ${item.title}`;
   }
 
-  render() {
-    this.deps.renderSessionQueue(this.session);
-    this.deps.renderPlaybackControls(this.session.activationState);
+  #render() {
+    this.#deps.renderSessionQueue(this.#session);
+    this.#deps.renderPlaybackControls(this.#session.activationState);
   }
 }
 

--- a/src/panels/auth-panel.js
+++ b/src/panels/auth-panel.js
@@ -1,14 +1,10 @@
+/** @typedef {{loginBtn: HTMLButtonElement; logoutBtn: HTMLButtonElement; authStatus: HTMLParagraphElement;}} AuthPanelElements */
+
 export class AuthPanel {
-  /** @type {{loginBtn: HTMLButtonElement; logoutBtn: HTMLButtonElement; authStatus: HTMLParagraphElement;}} */
+  /** @type {AuthPanelElements} */
   #el;
 
-  /**
-   * @param {{
-   *  loginBtn: HTMLButtonElement;
-   *  logoutBtn: HTMLButtonElement;
-   *  authStatus: HTMLParagraphElement;
-   * }} el
-   */
+  /** @param {AuthPanelElements} el */
   constructor(el) {
     this.#el = el;
   }

--- a/src/panels/auth-panel.js
+++ b/src/panels/auth-panel.js
@@ -1,4 +1,7 @@
 export class AuthPanel {
+  /** @type {{loginBtn: HTMLButtonElement; logoutBtn: HTMLButtonElement; authStatus: HTMLParagraphElement;}} */
+  #el;
+
   /**
    * @param {{
    *  loginBtn: HTMLButtonElement;
@@ -7,18 +10,17 @@ export class AuthPanel {
    * }} el
    */
   constructor(el) {
-    /** @type {{loginBtn: HTMLButtonElement; logoutBtn: HTMLButtonElement; authStatus: HTMLParagraphElement;}} */
-    this.el = el;
+    this.#el = el;
   }
 
   /** @param {{ onLogin: () => void; onLogout: () => void }} handlers */
   bind(handlers) {
-    this.el.loginBtn.addEventListener('click', handlers.onLogin);
-    this.el.logoutBtn.addEventListener('click', handlers.onLogout);
+    this.#el.loginBtn.addEventListener('click', handlers.onLogin);
+    this.#el.logoutBtn.addEventListener('click', handlers.onLogout);
   }
 
   /** @param {string} message */
   renderStatus(message) {
-    this.el.authStatus.textContent = message;
+    this.#el.authStatus.textContent = message;
   }
 }

--- a/src/panels/items-panel.js
+++ b/src/panels/items-panel.js
@@ -1,6 +1,10 @@
 /** @typedef {{uri: string; title: string}} ShuffleItem */
 
 export class ItemsPanel {
+  /** @type {{addForm: HTMLFormElement; itemUri: HTMLInputElement; importPlaylistBtn: HTMLButtonElement; itemList: HTMLUListElement;}} */
+  #el;
+  /** @type {(uri: string) => void} */
+  #onRemove;
   /**
    * @param {{
    *  addForm: HTMLFormElement;
@@ -10,10 +14,8 @@ export class ItemsPanel {
    * }} el
    */
   constructor(el) {
-    /** @type {{addForm: HTMLFormElement; itemUri: HTMLInputElement; importPlaylistBtn: HTMLButtonElement; itemList: HTMLUListElement;}} */
-    this.el = el;
-    /** @type {(uri: string) => void} */
-    this.onRemove = () => {};
+    this.#el = el;
+    this.#onRemove = () => {};
   }
 
   /**
@@ -24,18 +26,18 @@ export class ItemsPanel {
    * }} handlers
    */
   bind(handlers) {
-    this.el.addForm.addEventListener('submit', (event) => {
+    this.#el.addForm.addEventListener('submit', (event) => {
       event.preventDefault();
-      handlers.onAdd(this.el.itemUri.value.trim());
+      handlers.onAdd(this.#el.itemUri.value.trim());
     });
 
-    this.el.importPlaylistBtn.addEventListener('click', handlers.onImportPlaylist);
-    this.onRemove = handlers.onRemove;
+    this.#el.importPlaylistBtn.addEventListener('click', handlers.onImportPlaylist);
+    this.#onRemove = handlers.onRemove;
   }
 
   /** @param {ShuffleItem[]} items */
   renderList(items) {
-    this.el.itemList.innerHTML = '';
+    this.#el.itemList.innerHTML = '';
 
     for (const item of items) {
       const li = document.createElement('li');
@@ -50,21 +52,21 @@ export class ItemsPanel {
       removeButton.className = 'danger';
       removeButton.textContent = 'Remove';
       removeButton.addEventListener('click', () => {
-        this.onRemove(item.uri);
+        this.#onRemove(item.uri);
       });
 
       actions.appendChild(removeButton);
       li.append(text, actions);
-      this.el.itemList.appendChild(li);
+      this.#el.itemList.appendChild(li);
     }
   }
 
   clearInput() {
-    this.el.itemUri.value = '';
+    this.#el.itemUri.value = '';
   }
 
   /** @returns {string} */
   getUriInput() {
-    return this.el.itemUri.value.trim();
+    return this.#el.itemUri.value.trim();
   }
 }

--- a/src/panels/items-panel.js
+++ b/src/panels/items-panel.js
@@ -1,18 +1,12 @@
 /** @typedef {{uri: string; title: string}} ShuffleItem */
+/** @typedef {{addForm: HTMLFormElement; itemUri: HTMLInputElement; importPlaylistBtn: HTMLButtonElement; itemList: HTMLUListElement;}} ItemsPanelElements */
 
 export class ItemsPanel {
-  /** @type {{addForm: HTMLFormElement; itemUri: HTMLInputElement; importPlaylistBtn: HTMLButtonElement; itemList: HTMLUListElement;}} */
+  /** @type {ItemsPanelElements} */
   #el;
   /** @type {(uri: string) => void} */
   #onRemove;
-  /**
-   * @param {{
-   *  addForm: HTMLFormElement;
-   *  itemUri: HTMLInputElement;
-   *  importPlaylistBtn: HTMLButtonElement;
-   *  itemList: HTMLUListElement;
-   * }} el
-   */
+  /** @param {ItemsPanelElements} el */
   constructor(el) {
     this.#el = el;
     this.#onRemove = () => {};

--- a/src/panels/session-panel.js
+++ b/src/panels/session-panel.js
@@ -1,6 +1,8 @@
 /** @typedef {{title: string}} QueueItem */
 
 export class SessionPanel {
+  /** @type {{startBtn: HTMLButtonElement; reattachBtn: HTMLButtonElement; skipBtn: HTMLButtonElement; stopBtn: HTMLButtonElement; playbackStatus: HTMLParagraphElement; queueList: HTMLUListElement;}} */
+  #el;
   /**
    * @param {{
    *  startBtn: HTMLButtonElement;
@@ -12,18 +14,17 @@ export class SessionPanel {
    * }} el
    */
   constructor(el) {
-    /** @type {{startBtn: HTMLButtonElement; reattachBtn: HTMLButtonElement; skipBtn: HTMLButtonElement; stopBtn: HTMLButtonElement; playbackStatus: HTMLParagraphElement; queueList: HTMLUListElement;}} */
-    this.el = el;
+    this.#el = el;
   }
 
   /**
    * @param {{ onStart: () => void; onReattach: () => void; onSkip: () => void; onStop: () => void }} handlers
    */
   bind(handlers) {
-    this.el.startBtn.addEventListener('click', handlers.onStart);
-    this.el.reattachBtn.addEventListener('click', handlers.onReattach);
-    this.el.skipBtn.addEventListener('click', handlers.onSkip);
-    this.el.stopBtn.addEventListener('click', handlers.onStop);
+    this.#el.startBtn.addEventListener('click', handlers.onStart);
+    this.#el.reattachBtn.addEventListener('click', handlers.onReattach);
+    this.#el.skipBtn.addEventListener('click', handlers.onSkip);
+    this.#el.stopBtn.addEventListener('click', handlers.onStop);
   }
 
   /** @param {'inactive' | 'active' | 'detached'} activationState */
@@ -32,23 +33,23 @@ export class SessionPanel {
     const isActive = activationState === 'active';
     const isDetached = activationState === 'detached';
 
-    this.el.startBtn.disabled = !isInactive;
-    this.el.skipBtn.disabled = !isActive;
-    this.el.stopBtn.disabled = isInactive;
-    this.el.reattachBtn.hidden = !isDetached;
-    this.el.reattachBtn.disabled = !isDetached;
+    this.#el.startBtn.disabled = !isInactive;
+    this.#el.skipBtn.disabled = !isActive;
+    this.#el.stopBtn.disabled = isInactive;
+    this.#el.reattachBtn.hidden = !isDetached;
+    this.#el.reattachBtn.disabled = !isDetached;
   }
 
   /** @param {string} message */
   renderPlaybackStatus(message) {
-    this.el.playbackStatus.textContent = message;
+    this.#el.playbackStatus.textContent = message;
   }
 
   /**
    * @param {{activationState: 'inactive' | 'active' | 'detached'; queue: QueueItem[]; index: number}} session
    */
   renderQueue(session) {
-    this.el.queueList.innerHTML = '';
+    this.#el.queueList.innerHTML = '';
     if (session.activationState === 'inactive' || session.queue.length === 0) return;
 
     for (let i = 0; i < session.queue.length; i += 1) {
@@ -59,7 +60,7 @@ export class SessionPanel {
       }
       const marker = i === session.index ? '▶' : '•';
       li.textContent = `${marker} ${i + 1}. ${item.title}`;
-      this.el.queueList.appendChild(li);
+      this.#el.queueList.appendChild(li);
     }
   }
 }

--- a/src/panels/session-panel.js
+++ b/src/panels/session-panel.js
@@ -1,18 +1,10 @@
 /** @typedef {{title: string}} QueueItem */
+/** @typedef {{startBtn: HTMLButtonElement; reattachBtn: HTMLButtonElement; skipBtn: HTMLButtonElement; stopBtn: HTMLButtonElement; playbackStatus: HTMLParagraphElement; queueList: HTMLUListElement;}} SessionPanelElements */
 
 export class SessionPanel {
-  /** @type {{startBtn: HTMLButtonElement; reattachBtn: HTMLButtonElement; skipBtn: HTMLButtonElement; stopBtn: HTMLButtonElement; playbackStatus: HTMLParagraphElement; queueList: HTMLUListElement;}} */
+  /** @type {SessionPanelElements} */
   #el;
-  /**
-   * @param {{
-   *  startBtn: HTMLButtonElement;
-   *  reattachBtn: HTMLButtonElement;
-   *  skipBtn: HTMLButtonElement;
-   *  stopBtn: HTMLButtonElement;
-   *  playbackStatus: HTMLParagraphElement;
-   *  queueList: HTMLUListElement;
-   * }} el
-   */
+  /** @param {SessionPanelElements} el */
   constructor(el) {
     this.#el = el;
   }

--- a/src/panels/storage-panel.js
+++ b/src/panels/storage-panel.js
@@ -1,4 +1,6 @@
 export class StoragePanel {
+  /** @type {{exportStorageBtn: HTMLButtonElement; importStorageBtn: HTMLButtonElement; storageJson: HTMLTextAreaElement;}} */
+  #el;
   /**
    * @param {{
    *  exportStorageBtn: HTMLButtonElement;
@@ -7,23 +9,22 @@ export class StoragePanel {
    * }} el
    */
   constructor(el) {
-    /** @type {{exportStorageBtn: HTMLButtonElement; importStorageBtn: HTMLButtonElement; storageJson: HTMLTextAreaElement;}} */
-    this.el = el;
+    this.#el = el;
   }
 
   /** @param {{ onExport: () => void; onImport: () => void }} handlers */
   bind(handlers) {
-    this.el.exportStorageBtn.addEventListener('click', handlers.onExport);
-    this.el.importStorageBtn.addEventListener('click', handlers.onImport);
+    this.#el.exportStorageBtn.addEventListener('click', handlers.onExport);
+    this.#el.importStorageBtn.addEventListener('click', handlers.onImport);
   }
 
   /** @returns {string} */
   getJsonInput() {
-    return this.el.storageJson.value;
+    return this.#el.storageJson.value;
   }
 
   /** @param {string} value */
   setJsonInput(value) {
-    this.el.storageJson.value = value;
+    this.#el.storageJson.value = value;
   }
 }

--- a/src/panels/storage-panel.js
+++ b/src/panels/storage-panel.js
@@ -1,13 +1,9 @@
+/** @typedef {{exportStorageBtn: HTMLButtonElement; importStorageBtn: HTMLButtonElement; storageJson: HTMLTextAreaElement;}} StoragePanelElements */
+
 export class StoragePanel {
-  /** @type {{exportStorageBtn: HTMLButtonElement; importStorageBtn: HTMLButtonElement; storageJson: HTMLTextAreaElement;}} */
+  /** @type {StoragePanelElements} */
   #el;
-  /**
-   * @param {{
-   *  exportStorageBtn: HTMLButtonElement;
-   *  importStorageBtn: HTMLButtonElement;
-   *  storageJson: HTMLTextAreaElement;
-   * }} el
-   */
+  /** @param {StoragePanelElements} el */
   constructor(el) {
     this.#el = el;
   }

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -43,57 +43,56 @@ export class PlayerMonitorStatusError extends Error {
 
 export class PlayerMonitor {
   /** @type {PlayerMonitorDeps} */
-  deps;
-
+  #deps;
   /** @type {ReturnType<typeof setInterval> | null} */
-  monitorTimer;
+  #monitorTimer;
 
   /** @param {PlayerMonitorDeps} deps */
   constructor(deps) {
-    this.deps = deps;
-    this.monitorTimer = null;
+    this.#deps = deps;
+    this.#monitorTimer = null;
   }
 
   start() {
     this.stop();
-    this.monitorTimer = globalThis.setInterval(() => {
+    this.#monitorTimer = globalThis.setInterval(() => {
       void (async () => {
         try {
           await this.monitorPlayback();
         } catch (error) {
-          this.deps.reportError(error);
+          this.#deps.reportError(error);
         }
       })();
     }, 4000);
   }
 
   stop() {
-    if (this.monitorTimer !== null) {
-      clearInterval(this.monitorTimer);
-      this.monitorTimer = null;
+    if (this.#monitorTimer !== null) {
+      clearInterval(this.#monitorTimer);
+      this.#monitorTimer = null;
     }
   }
 
   async monitorPlayback() {
-    const session = this.deps.getSession();
+    const session = this.#deps.getSession();
     if (session.activationState !== 'active' || !session.currentUri) return;
 
-    const token = await this.deps.getUsableAccessToken();
+    const token = await this.#deps.getUsableAccessToken();
     if (!token) {
-      this.deps.transitionToDetached('Spotify session expired. Please reconnect.');
+      this.#deps.transitionToDetached('Spotify session expired. Please reconnect.');
       return;
     }
 
-    const playerState = await this.deps.spotifyAppApi.getPlayerState();
+    const playerState = await this.#deps.spotifyAppApi.getPlayerState();
     if (!playerState.ok) {
-      if (this.deps.isUnrecoverableSpotifyStatus(playerState.status)) {
-        this.deps.transitionToDetached(
+      if (this.#deps.isUnrecoverableSpotifyStatus(playerState.status)) {
+        this.#deps.transitionToDetached(
           spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached.'),
         );
         return;
       }
 
-      this.deps.reportError(new PlayerMonitorStatusError(playerState.status, playerState.errorText));
+      this.#deps.reportError(new PlayerMonitorStatusError(playerState.status, playerState.errorText));
       return;
     }
 
@@ -101,7 +100,7 @@ export class PlayerMonitor {
 
     if (contextUri === session.currentUri) {
       session.observedCurrentContext = true;
-      this.deps.persistRuntimeState();
+      this.#deps.persistRuntimeState();
       return;
     }
 
@@ -110,12 +109,12 @@ export class PlayerMonitor {
     }
 
     if (session.observedCurrentContext && contextUri === null) {
-      await this.deps.goToNextItem();
+      await this.#deps.goToNextItem();
       return;
     }
 
     if (contextUri && contextUri !== session.currentUri) {
-      this.deps.transitionToDetached(
+      this.#deps.transitionToDetached(
         'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
       );
     }

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -27,13 +27,13 @@ export class SpotifyApiHttpError extends Error {
 
 export class SpotifyApi {
   /** @type {SpotifyApiDeps} */
-  deps;
+  #deps;
 
   /**
    * @param {SpotifyApiDeps} deps
    */
   constructor(deps) {
-    this.deps = deps;
+    this.#deps = deps;
   }
 
   /**
@@ -53,21 +53,21 @@ export class SpotifyApi {
         },
       });
 
-    const token = await this.deps.getAccessToken();
+    const token = await this.#deps.getAccessToken();
     if (!token) {
-      this.deps.handleAuthExpired();
+      this.#deps.handleAuthExpired();
       throw new SpotifyApiHttpError(401, spotifyStatusMessage(401, `Spotify API request failed for ${path}.`));
     }
 
     let response = await makeRequest(token);
     if (response.status === 401) {
-      const refreshedToken = await this.deps.refreshSpotifyAccessToken();
+      const refreshedToken = await this.#deps.refreshSpotifyAccessToken();
       if (refreshedToken) {
         response = await makeRequest(refreshedToken);
       }
 
       if (response.status === 401) {
-        this.deps.handleAuthExpired();
+        this.#deps.handleAuthExpired();
       }
     }
 

--- a/src/spotify-app-api.js
+++ b/src/spotify-app-api.js
@@ -48,16 +48,16 @@
 
 export class SpotifyAppApi {
   /** @type {SpotifyApi} */
-  spotifyApi;
+  #spotifyApi;
 
   /** @param {SpotifyApi} spotifyApi */
   constructor(spotifyApi) {
-    this.spotifyApi = spotifyApi;
+    this.#spotifyApi = spotifyApi;
   }
 
   /** @returns {Promise<PlayerStateResponse>} */
   async getPlayerState() {
-    const response = await this.spotifyApi.request('/me/player', { method: 'GET' }, false);
+    const response = await this.#spotifyApi.request('/me/player', { method: 'GET' }, false);
     if (response.status === 204) {
       return { ok: true, status: response.status, contextUri: null };
     }
@@ -71,17 +71,17 @@ export class SpotifyAppApi {
 
   /** @returns {Promise<void>} */
   async disableShuffle() {
-    await this.spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' });
+    await this.#spotifyApi.request('/me/player/shuffle?state=false', { method: 'PUT' });
   }
 
   /** @returns {Promise<void>} */
   async disableRepeat() {
-    await this.spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' });
+    await this.#spotifyApi.request('/me/player/repeat?state=off', { method: 'PUT' });
   }
 
   /** @param {string} contextUri */
   async playContext(contextUri) {
-    await this.spotifyApi.request('/me/player/play', {
+    await this.#spotifyApi.request('/me/player/play', {
       method: 'PUT',
       body: JSON.stringify({
         context_uri: contextUri,
@@ -105,7 +105,7 @@ export class SpotifyAppApi {
       market: 'from_token',
     });
 
-    const response = await this.spotifyApi.request(
+    const response = await this.#spotifyApi.request(
       `/playlists/${playlistId}/items?${params.toString()}`,
       { method: 'GET' },
       false,
@@ -143,7 +143,7 @@ export class SpotifyAppApi {
    */
   async getItemTitle(itemType, id) {
     const path = itemType === 'album' ? `/albums/${id}` : `/playlists/${id}`;
-    const response = await this.spotifyApi.request(path, { method: 'GET' }, false);
+    const response = await this.#spotifyApi.request(path, { method: 'GET' }, false);
     if (!response.ok) return null;
 
     const data = /** @type {{name?: string}} */ (await response.json());

--- a/src/ui/toast-presenter.js
+++ b/src/ui/toast-presenter.js
@@ -3,10 +3,12 @@ const TOAST_DURATION_MS = 5000;
 /** @typedef {{ actionLabel: string, onAction: () => void }} ToastAction */
 
 export class ToastPresenter {
+  /** @type {HTMLDivElement} */
+  #toastStack;
+
   /** @param {HTMLDivElement} toastStack */
   constructor(toastStack) {
-    /** @type {HTMLDivElement} */
-    this.toastStack = toastStack;
+    this.#toastStack = toastStack;
   }
 
   /**
@@ -73,6 +75,6 @@ export class ToastPresenter {
     toast.addEventListener('mouseleave', restartDismissTimer);
 
     toast.append(body, actions);
-    this.toastStack.appendChild(toast);
+    this.#toastStack.appendChild(toast);
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce the public surface of several classes by converting internal-only fields and helpers to ECMAScript private members so implementation details are hidden and accidental external use is prevented.

### Description
- Converted internal class state/dependency fields to private fields (`#...`) across panels, core, API, monitor, and toast presenter classes (examples: `AuthPanel`, `ItemsPanel`, `StoragePanel`, `SessionPanel`, `PlayerMonitor`, `SessionController`, `AuthFlow`, `ErrorReporter`, `ItemStore`, `SpotifyApi`, `SpotifyAppApi`, `ToastPresenter`).
- Converted `SessionController.render()` into a private helper `#render()` because it has no external callers, and updated all internal call sites to use the private helper. 
- Preserved public methods that have external callers (notably `PlayerMonitor.monitorPlayback` which is invoked directly by unit tests) and updated call sites to use the new private fields.
- Remaining public properties/methods and their external uses are: `PlayerMonitorStatusError.status` and `PlayerMonitorStatusError.errorText` used by monitor error reporting and tests; `AuthPanel.bind` and `AuthPanel.renderStatus` used by app bootstrap/event wiring (`src/app.js`); `ItemsPanel.bind`, `ItemsPanel.renderList`, `ItemsPanel.clearInput`, `ItemsPanel.getUriInput` used by app flows; `StoragePanel.bind`, `StoragePanel.getJsonInput`, `StoragePanel.setJsonInput` used by storage import/export in the app; `SessionPanel.bind`, `renderControls`, `renderPlaybackStatus`, `renderQueue` used by app render and event wiring; `PlayerMonitor.start`, `stop`, `monitorPlayback` used by `SessionController` and unit tests; `SessionController` public API methods (such as `setPlayerMonitor`, `getSession`, `startShuffleSession`, `stopSession`, `transitionToInactive`, `transitionToDetached`, `goToNextItem`, `reattachSession`, `playCurrentItem`, `restoreRuntimeState`, `persistRuntimeState`, `clearRuntimeState`, `formatNowPlayingStatus`) used by `src/app.js`; `AuthFlow` public methods (`startLogin`, `handleAuthRedirect`, `clearAuth`, `getToken`, `getGrantedScopes`, `refreshSpotifyAccessToken`, `getUsableAccessToken`) used by the app; `ErrorReporter.run` and `ErrorReporter.report` used by app helpers and tests; `ItemStore` API (`getItems`, `saveItems`, `exportData`, `importFromJson`, `removeByUri`, `restoreItem`) used by app flows; `SpotifyApi.request` used by `SpotifyAppApi`; `ToastPresenter.show` used by app `showToast`; and `SpotifyAppApi` methods used by session/app logic.

### Testing
- Ran `npm run check` which executes the project test and validation scripts, and the command completed successfully.
- All unit tests passed under the check run (30 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e025aebbc083219c415456ab608308)