### PR TITLE
refactor: privatize playback monitor cycle

### DIFF
--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -27,9 +27,6 @@ export class PlayerMonitorStatusError extends Error {
   /** @type {number} */
   status;
 
-  /** @type {string} */
-  errorText;
-
   /**
    * @param {number} status
    * @param {string} errorText
@@ -37,7 +34,6 @@ export class PlayerMonitorStatusError extends Error {
   constructor(status, errorText) {
     super(`Playback monitor request failed (${status}): ${errorText}`);
     this.status = status;
-    this.errorText = errorText;
   }
 }
 
@@ -58,7 +54,7 @@ export class PlayerMonitor {
     this.#monitorTimer = globalThis.setInterval(() => {
       void (async () => {
         try {
-          await this.monitorPlayback();
+          await this.#monitorPlayback();
         } catch (error) {
           this.#deps.reportError(error);
         }
@@ -73,7 +69,7 @@ export class PlayerMonitor {
     }
   }
 
-  async monitorPlayback() {
+  async #monitorPlayback() {
     const session = this.#deps.getSession();
     if (session.activationState !== 'active' || !session.currentUri) return;
 

--- a/tests/unit/player-monitor.test.js
+++ b/tests/unit/player-monitor.test.js
@@ -71,53 +71,11 @@ function createMonitor(options = {}) {
   };
 }
 
-test('monitorPlayback marks context as observed and persists when player context matches current uri', async () => {
-  const { session, monitor, spies } = createMonitor();
-
-  await monitor.monitorPlayback();
-
-  assert.equal(session.observedCurrentContext, true);
-  assert.equal(spies.persistRuntimeState.mock.callCount(), 1);
-  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
-});
-
-test('monitorPlayback detaches when token is unavailable', async () => {
-  const { monitor, detachedMessages, spies } = createMonitor({ token: null });
-
-  await monitor.monitorPlayback();
-
-  assert.deepEqual(detachedMessages, ['Spotify session expired. Please reconnect.']);
-  assert.equal(spies.getPlayerState.mock.callCount(), 0);
-});
-
-test('monitorPlayback reports recoverable player-state status errors', async () => {
-  const { monitor, reportedErrors } = createMonitor({
-    playerState: { ok: false, status: 429, errorText: 'slow down' },
-    isUnrecoverable: () => false,
-  });
-
-  await monitor.monitorPlayback();
-
-  assert.equal(reportedErrors.length, 1);
-  assert.ok(reportedErrors[0] instanceof PlayerMonitorStatusError);
-  const playerMonitorError = /** @type {PlayerMonitorStatusError} */ (reportedErrors[0]);
-  assert.equal(playerMonitorError.status, 429);
-  assert.equal(playerMonitorError.errorText, 'slow down');
-});
-
-test('monitorPlayback advances when observed context becomes null', async () => {
-  const { monitor, spies } = createMonitor({
-    observedCurrentContext: true,
-    playerState: { ok: true, contextUri: null },
-  });
-
-  await monitor.monitorPlayback();
-
-  assert.equal(spies.goToNextItem.mock.callCount(), 1);
-  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
-});
-
-test('start catches monitor loop errors and forwards them to reportError', async () => {
+/**
+ * @param {PlayerMonitor} monitor
+ * @returns {Promise<void>}
+ */
+async function runMonitorCycle(monitor) {
   /** @type {() => void} */
   let intervalCallback = () => {};
 
@@ -131,12 +89,62 @@ test('start catches monitor loop errors and forwards them to reportError', async
     },
   );
 
-  const { monitor, reportedErrors } = createMonitor({ playerStateError: new Error('boom') });
-
   monitor.start();
   assert.equal(setIntervalMock.mock.callCount(), 1);
   intervalCallback();
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('monitor loop marks context as observed and persists when player context matches current uri', async () => {
+  const { session, monitor, spies } = createMonitor();
+
+  await runMonitorCycle(monitor);
+
+  assert.equal(session.observedCurrentContext, true);
+  assert.equal(spies.persistRuntimeState.mock.callCount(), 1);
+  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
+});
+
+test('monitor loop detaches when token is unavailable', async () => {
+  const { monitor, detachedMessages, spies } = createMonitor({ token: null });
+
+  await runMonitorCycle(monitor);
+
+  assert.deepEqual(detachedMessages, ['Spotify session expired. Please reconnect.']);
+  assert.equal(spies.getPlayerState.mock.callCount(), 0);
+});
+
+test('monitor loop reports recoverable player-state status errors', async () => {
+  const { monitor, reportedErrors } = createMonitor({
+    playerState: { ok: false, status: 429, errorText: 'slow down' },
+    isUnrecoverable: () => false,
+  });
+
+  await runMonitorCycle(monitor);
+
+  assert.equal(reportedErrors.length, 1);
+  assert.ok(reportedErrors[0] instanceof PlayerMonitorStatusError);
+  const playerMonitorError = /** @type {PlayerMonitorStatusError} */ (reportedErrors[0]);
+  assert.equal(playerMonitorError.status, 429);
+  assert.match(playerMonitorError.message, /slow down/);
+});
+
+test('monitor loop advances when observed context becomes null', async () => {
+  const { monitor, spies } = createMonitor({
+    observedCurrentContext: true,
+    playerState: { ok: true, contextUri: null },
+  });
+
+  await runMonitorCycle(monitor);
+
+  assert.equal(spies.goToNextItem.mock.callCount(), 1);
+  assert.equal(spies.transitionToDetached.mock.callCount(), 0);
+});
+
+test('start catches monitor loop errors and forwards them to reportError', async () => {
+  const { monitor, reportedErrors } = createMonitor({ playerStateError: new Error('boom') });
+
+  await runMonitorCycle(monitor);
 
   assert.equal(reportedErrors.length, 1);
   assert.ok(reportedErrors[0] instanceof Error);

--- a/tests/unit/player-monitor.test.js
+++ b/tests/unit/player-monitor.test.js
@@ -126,7 +126,7 @@ test('monitor loop reports recoverable player-state status errors', async () => 
   assert.ok(reportedErrors[0] instanceof PlayerMonitorStatusError);
   const playerMonitorError = /** @type {PlayerMonitorStatusError} */ (reportedErrors[0]);
   assert.equal(playerMonitorError.status, 429);
-  assert.match(playerMonitorError.message, /slow down/);
+  assert.equal(playerMonitorError.message, 'Playback monitor request failed (429): slow down');
 });
 
 test('monitor loop advances when observed context becomes null', async () => {


### PR DESCRIPTION
### Motivation

- Reduce unused surface area on the error type by removing the redundant `errorText` instance property while keeping the original text in the error message. 
- Encapsulate the playback polling logic by making the monitor method private to reflect that it should only be invoked by the monitor loop. 
- Update unit tests to exercise the public `start()` loop instead of calling the formerly-public method directly so tests match the new visibility.

### Description

- Remove the unused `PlayerMonitorStatusError.errorText` property and retain `status` and the full error text in the `Error` message. 
- Rename `monitorPlayback` to a private method `#monitorPlayback` and update `start()` to call `await this.#monitorPlayback()` inside the interval loop. 
- Update `tests/unit/player-monitor.test.js` to add a `runMonitorCycle` helper that mocks `setInterval` and drives a single loop execution using `monitor.start()`, and adjust assertions that previously inspected `errorText` to check the error `message` instead.

### Testing

- Ran `npm run check`, which runs the full test suite, and all tests passed (30 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e039f192988321a21f65c390f711c0)