### PR TITLE
refactor: convert multiline typedefs to @property format

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -640,14 +640,13 @@ function reportError(error, options) {
 }
 
 /**
- * @typedef {{
- *   context: string;
- *   fallbackMessage: string;
- *   authStatusMessage?: string;
- *   playbackStatusMessage?: string;
- *   toastMode?: 'always' | 'cooldown';
- *   toastKey?: string;
- * }} ErrorReportOptions
+ * @typedef ErrorReportOptions
+ * @property {string} context
+ * @property {string} fallbackMessage
+ * @property {string} [authStatusMessage]
+ * @property {string} [playbackStatusMessage]
+ * @property {'always' | 'cooldown'} [toastMode]
+ * @property {string} [toastKey]
  */
 
 /**

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -1,11 +1,10 @@
 /**
- * @typedef {{
- *  scopes: string[];
- *  spotifyAppId: string;
- *  storageKeys: { verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; };
- *  reportError: (error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void;
- *  setAuthStatus: (message: string) => void;
- * }} AuthFlowDeps
+ * @typedef AuthFlowDeps
+ * @property {string[]} scopes
+ * @property {string} spotifyAppId
+ * @property {{ verifier: string; token: string; refreshToken: string; tokenExpiry: string; tokenScope: string; }} storageKeys
+ * @property {(error: unknown, options: {context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string;}) => void} reportError
+ * @property {(message: string) => void} setAuthStatus
  */
 
 export class AuthFlow {

--- a/src/core/error-reporter.js
+++ b/src/core/error-reporter.js
@@ -57,14 +57,13 @@ export class ErrorReporter {
 }
 
 /**
- * @typedef {{
- *   context: string;
- *   fallbackMessage: string;
- *   authStatusMessage?: string;
- *   playbackStatusMessage?: string;
- *   toastMode?: 'always' | 'cooldown';
- *   toastKey?: string;
- * }} ErrorReportOptions
+ * @typedef ErrorReportOptions
+ * @property {string} context
+ * @property {string} fallbackMessage
+ * @property {string} [authStatusMessage]
+ * @property {string} [playbackStatusMessage]
+ * @property {'always' | 'cooldown'} [toastMode]
+ * @property {string} [toastKey]
  */
 
 /**

--- a/src/core/session-controller.js
+++ b/src/core/session-controller.js
@@ -3,21 +3,20 @@
 /** @typedef {'inactive' | 'active' | 'detached'} SessionActivationState */
 
 /**
- * @typedef {{
- *  runtimeStorageKey: string;
- *  getUsableAccessToken: () => Promise<string | null>;
- *  spotifyAppApi: import('../spotify-app-api.js').SpotifyAppApi;
- *  showToast: (message: string, type?: 'success' | 'info' | 'error') => void;
- *  setPlaybackStatus: (message: string) => void;
- *  renderPlaybackControls: (activationState: SessionActivationState) => void;
- *  renderSessionQueue: (session: SessionState) => void;
- *  reportError: (error: unknown, options: {context: string; fallbackMessage: string; playbackStatusMessage?: string; toastMode?: 'always' | 'cooldown'; toastKey?: string;}) => void;
- *  isUnrecoverableSpotifyError: (error: unknown) => boolean;
- *  isUnrecoverableSpotifyStatus: (status: number) => boolean;
- *  spotifyStatusMessage: (status: number, fallback: string) => string;
- *  getItems: () => ShuffleItem[];
- *  shuffledCopy: (items: ShuffleItem[]) => ShuffleItem[];
- * }} SessionControllerDeps
+ * @typedef SessionControllerDeps
+ * @property {string} runtimeStorageKey
+ * @property {() => Promise<string | null>} getUsableAccessToken
+ * @property {import('../spotify-app-api.js').SpotifyAppApi} spotifyAppApi
+ * @property {(message: string, type?: 'success' | 'info' | 'error') => void} showToast
+ * @property {(message: string) => void} setPlaybackStatus
+ * @property {(activationState: SessionActivationState) => void} renderPlaybackControls
+ * @property {(session: SessionState) => void} renderSessionQueue
+ * @property {(error: unknown, options: {context: string; fallbackMessage: string; playbackStatusMessage?: string; toastMode?: 'always' | 'cooldown'; toastKey?: string;}) => void} reportError
+ * @property {(error: unknown) => boolean} isUnrecoverableSpotifyError
+ * @property {(status: number) => boolean} isUnrecoverableSpotifyStatus
+ * @property {(status: number, fallback: string) => string} spotifyStatusMessage
+ * @property {() => ShuffleItem[]} getItems
+ * @property {(items: ShuffleItem[]) => ShuffleItem[]} shuffledCopy
  */
 
 export class SessionController {

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -3,24 +3,22 @@ import { spotifyStatusMessage } from './spotify-status-message.js';
 /** @typedef {import('./spotify-app-api.js').SpotifyAppApi} SpotifyAppApi */
 
 /**
- * @typedef {{
- *   activationState: 'inactive' | 'active' | 'detached';
- *   currentUri: string | null;
- *   observedCurrentContext: boolean;
- * }} MonitorSession
+ * @typedef MonitorSession
+ * @property {'inactive' | 'active' | 'detached'} activationState
+ * @property {string | null} currentUri
+ * @property {boolean} observedCurrentContext
  */
 
 /**
- * @typedef {{
- *   getSession: () => MonitorSession;
- *   getUsableAccessToken: () => Promise<string | null>;
- *   spotifyAppApi: SpotifyAppApi;
- *   persistRuntimeState: () => void;
- *   transitionToDetached: (message: string) => void;
- *   goToNextItem: () => Promise<void>;
- *   reportError: (error: unknown) => void;
- *   isUnrecoverableSpotifyStatus: (status: number) => boolean;
- * }} PlayerMonitorDeps
+ * @typedef PlayerMonitorDeps
+ * @property {() => MonitorSession} getSession
+ * @property {() => Promise<string | null>} getUsableAccessToken
+ * @property {SpotifyAppApi} spotifyAppApi
+ * @property {() => void} persistRuntimeState
+ * @property {(message: string) => void} transitionToDetached
+ * @property {() => Promise<void>} goToNextItem
+ * @property {(error: unknown) => void} reportError
+ * @property {(status: number) => boolean} isUnrecoverableSpotifyStatus
  */
 
 export class PlayerMonitorStatusError extends Error {

--- a/src/spotify-api.js
+++ b/src/spotify-api.js
@@ -18,11 +18,10 @@ export class SpotifyApiHttpError extends Error {
 }
 
 /**
- * @typedef {{
- * getAccessToken: () => Promise<string | null>;
- * refreshSpotifyAccessToken: () => Promise<string | null>;
- * handleAuthExpired: () => void;
- * }} SpotifyApiDeps
+ * @typedef SpotifyApiDeps
+ * @property {() => Promise<string | null>} getAccessToken
+ * @property {() => Promise<string | null>} refreshSpotifyAccessToken
+ * @property {() => void} handleAuthExpired
  */
 
 export class SpotifyApi {

--- a/src/spotify-app-api.js
+++ b/src/spotify-app-api.js
@@ -3,45 +3,40 @@
 /** @typedef {'album' | 'playlist'} ItemType */
 
 /**
- * @typedef {{
- *   ok: true;
- *   status: number;
- *   contextUri: string | null;
- * }} PlayerStateSuccess
+ * @typedef PlayerStateSuccess
+ * @property {true} ok
+ * @property {number} status
+ * @property {string | null} contextUri
  */
 
 /**
- * @typedef {{
- *   ok: false;
- *   status: number;
- *   errorText: string;
- * }} PlayerStateFailure
+ * @typedef PlayerStateFailure
+ * @property {false} ok
+ * @property {number} status
+ * @property {string} errorText
  */
 
 /** @typedef {PlayerStateSuccess | PlayerStateFailure} PlayerStateResponse */
 
 /**
- * @typedef {{
- *   uri: string;
- *   title: string;
- * }} PlaylistAlbum
+ * @typedef PlaylistAlbum
+ * @property {string} uri
+ * @property {string} title
  */
 
 /**
- * @typedef {{
- *   ok: true;
- *   status: number;
- *   albums: PlaylistAlbum[];
- *   hasNext: boolean;
- * }} PlaylistAlbumsPageSuccess
+ * @typedef PlaylistAlbumsPageSuccess
+ * @property {true} ok
+ * @property {number} status
+ * @property {PlaylistAlbum[]} albums
+ * @property {boolean} hasNext
  */
 
 /**
- * @typedef {{
- *   ok: false;
- *   status: number;
- *   errorText: string;
- * }} PlaylistAlbumsPageFailure
+ * @typedef PlaylistAlbumsPageFailure
+ * @property {false} ok
+ * @property {number} status
+ * @property {string} errorText
  */
 
 /** @typedef {PlaylistAlbumsPageSuccess | PlaylistAlbumsPageFailure} PlaylistAlbumsPageResponse */


### PR DESCRIPTION
### Motivation
- Normalize JSDoc typedefs to a consistent `@typedef Name` + `@property` style for multi-line shapes to improve readability and editor/type-checker support.
- Preserve existing single-line typedefs and maintain the same type semantics after conversion.

### Description
- Converted multi-line `@typedef {{ ... }}` blocks to `@typedef Name` plus `@property` entries across several modules, including `src/app.js`, `src/player-monitor.js`, `src/core/error-reporter.js`, `src/core/auth-flow.js`, `src/core/session-controller.js`, `src/spotify-app-api.js`, and `src/spotify-api.js`.
- Updated optional properties to bracket notation (e.g. `@property {string} [authStatusMessage]`) where required so optionality is preserved for the type-checker.
- Kept single-line typedefs (e.g. `/** @typedef {{uri: string; title: string}} ShuffleItem */`) unchanged.
- Ensured small formatting adjustments to maintain consistent JSDoc layout and preserve existing inline import/type references.

### Testing
- Ran `npm run check`, which executes the test suite and type checks, and it completed successfully.
- All unit tests passed (`30` tests passed) and TypeScript/JSDoc-based checks reported no remaining typedef-related errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e03dd2edf0832195a7fe96fdb8b869)