### PR TITLE
Update import/export copy in data panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <main>
       <h1>Shuffle By Album</h1>
       <p>
-        Randomly cycles through your saved set of Spotify albums/playlists while keeping
+        Randomly cycles through a saved set of Spotify albums/playlists while keeping
         each item's tracks in order.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -63,8 +63,10 @@
             Import Data
           </button>
         </div>
-        <p class="small"><b>Export Data</b> copies your saved items into the text box</p>
-        <p class="small"><b>Import Data</b> replaces your saved items with the data in the text box</p>
+        <p class="small">
+          <b>Export Data</b> copies your saved items into the text box<br />
+          <b>Import Data</b> replaces your saved items with the data in the text box
+        </p>
         <textarea
           id="storage-json"
           rows="10"

--- a/index.html
+++ b/index.html
@@ -58,23 +58,18 @@
       <section class="panel">
         <h2>4) Import / Export Data</h2>
         <div class="row">
-          <button id="export-storage-btn" type="button">Export Data JSON</button>
+          <button id="export-storage-btn" type="button">Export Data</button>
           <button id="import-storage-btn" type="button" class="secondary">
-            Import Data JSON
+            Import Data
           </button>
         </div>
-        <label>
-          Data JSON
-          <textarea
-            id="storage-json"
-            rows="10"
-            placeholder='{"shuffle-by-album.items":[{"type":"album","uri":...'
-          ></textarea>
-        </label>
-        <p class="small">
-          Export copies your saved items into the text box.  Import replaces saved items with the
-          data in the text box.
-        </p>
+        <p class="small"><b>Export Data</b> copies your saved items into the text box</p>
+        <p class="small"><b>Import Data</b> replaces your saved items with the data in the text box</p>
+        <textarea
+          id="storage-json"
+          rows="10"
+          placeholder='{"shuffle-by-album.items":[{"type":"album","uri":...'
+        ></textarea>
       </section>
     </main>
 

--- a/tests/ui/storage-json-ui.spec.js
+++ b/tests/ui/storage-json-ui.spec.js
@@ -37,27 +37,27 @@ test.describe('Storage JSON Import/Export', () => {
     await page.getByRole('button', { name: 'Start' }).click();
     await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
 
-    await page.getByRole('button', { name: 'Export Data JSON' }).click();
+    await page.getByRole('button', { name: 'Export Data' }).click();
     await expect(page.locator('#storage-json')).toHaveValue(/"shuffle-by-album.items"/);
 
     await page.locator('#storage-json').fill('');
-    await page.getByRole('button', { name: 'Import Data JSON' }).click();
+    await page.getByRole('button', { name: 'Import Data' }).click();
     await expect(page.getByText('Paste a JSON object to import.', { exact: true })).toBeVisible();
 
     await page.locator('#storage-json').fill('{bad}');
-    await page.getByRole('button', { name: 'Import Data JSON' }).click();
+    await page.getByRole('button', { name: 'Import Data' }).click();
     await expect(page.getByText('Invalid JSON. Please provide a valid JSON object.', { exact: true })).toBeVisible();
 
     await page.locator('#storage-json').fill('[]');
-    await page.getByRole('button', { name: 'Import Data JSON' }).click();
+    await page.getByRole('button', { name: 'Import Data' }).click();
     await expect(page.getByText('Import JSON must be an object of key/value pairs.', { exact: true })).toBeVisible();
 
     await page.locator('#storage-json').fill('{"other":[]}');
-    await page.getByRole('button', { name: 'Import Data JSON' }).click();
+    await page.getByRole('button', { name: 'Import Data' }).click();
     await expect(page.getByText('Import JSON must include a valid shuffle-by-album.items array.', { exact: true })).toBeVisible();
 
     await page.locator('#storage-json').fill('{"shuffle-by-album.items":[{"type":"album","uri":"spotify:album:no-title"}]}');
-    await page.getByRole('button', { name: 'Import Data JSON' }).click();
+    await page.getByRole('button', { name: 'Import Data' }).click();
     await expect(page.getByText('spotify:album:no-title', { exact: true })).toBeVisible();
     await expect(page.getByText('Data imported. Session reset.', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Next' })).toBeDisabled();
@@ -70,7 +70,7 @@ test.describe('Storage JSON Import/Export', () => {
 
     await page.goto('/');
 
-    await page.getByRole('button', { name: 'Export Data JSON' }).click();
+    await page.getByRole('button', { name: 'Export Data' }).click();
     await expect(page.locator('#storage-json')).toHaveValue('');
     await expect(
       page.getByText('Unable to export saved items because stored data is invalid JSON.', { exact: true }),


### PR DESCRIPTION
### Motivation
- Simplify the import/export UI by removing redundant “JSON” from action labels and helper copy.
- Make the helper text match the bold-prefix style used in the Add / Import Albums controls for consistency.
- Surface clearer guidance about what `Export Data` and `Import Data` do directly above the textarea.
- Ensure automated UI tests keep working by updating selectors to the new button labels.

### Description
- Renamed the storage transfer buttons in `index.html` from `Export Data JSON`/`Import Data JSON` to `Export Data`/`Import Data`.
- Removed the `Data JSON` label and placed two helper lines above the textarea using the same `<b>…</b>` formatting as other panels.
- Moved the `<textarea id="storage-json">` below the new helper lines and preserved its placeholder and attributes.
- Updated `tests/ui/storage-json-ui.spec.js` to click the renamed buttons (`Export Data` / `Import Data`).

### Testing
- Ran `npm run check` and all automated tests completed successfully with `30` passing tests and `0` failures.
- The updated UI tests in `tests/ui/storage-json-ui.spec.js` exercised the import/export flows and passed under the `check` run.
- Verified the app build/test script `scripts/check` exited with success after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1bf2bb5008321825f889e9d69bb78)