### PR TITLE
Preserve OAuth redirect errors in startup auth status

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -318,11 +318,18 @@ function refreshAuthStatus() {
 }
 
 function refreshStartupAuthStatus() {
+  const redirectStatus = authFlow.consumePendingRedirectStatus();
+  if (redirectStatus && !getToken()) {
+    setAuthStatus(redirectStatus);
+    return;
+  }
+
   const refreshFailureStatus = authFlow.consumePendingRefreshFailureStatus();
   if (refreshFailureStatus && !getToken()) {
     setAuthStatus(refreshFailureStatus);
     return;
   }
+
   refreshAuthStatus();
 }
 

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -15,10 +15,13 @@ export class AuthFlow {
   #deps;
   /** @type {string | null} */
   #pendingRefreshFailureStatus;
+  /** @type {string | null} */
+  #pendingRedirectStatus;
   /** @param {AuthFlowDeps} deps */
   constructor(deps) {
     this.#deps = deps;
     this.#pendingRefreshFailureStatus = null;
+    this.#pendingRedirectStatus = null;
   }
 
   async startLogin() {
@@ -43,6 +46,8 @@ export class AuthFlow {
   }
 
   async handleAuthRedirect() {
+    this.#pendingRedirectStatus = null;
+
     const locationRef = /** @type {{origin: string; pathname: string; href: string}} */ (
       /** @type {unknown} */ (Reflect.get(globalThis, 'location'))
     );
@@ -59,7 +64,9 @@ export class AuthFlow {
     };
 
     if (error) {
-      this.#deps.setAuthStatus(`Spotify authorization error: ${error}`);
+      const status = `Spotify authorization error: ${error}`;
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       localStorage.removeItem(this.#deps.storageKeys.verifier);
       clearHandledRedirectUrl();
       return;
@@ -70,7 +77,9 @@ export class AuthFlow {
     const verifier = localStorage.getItem(this.#deps.storageKeys.verifier);
 
     if (!verifier) {
-      this.#deps.setAuthStatus('Missing PKCE verifier. Try connecting again.');
+      const status = 'Missing PKCE verifier. Try connecting again.';
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -93,11 +102,11 @@ export class AuthFlow {
       });
     } catch (error) {
       localStorage.removeItem(this.#deps.storageKeys.verifier);
-      this.#deps.setAuthStatus(
-        tokenExchangeFailureStatus(
-          userFacingErrorMessage(error, 'Network error while contacting Spotify. Please try again.'),
-        ),
+      const status = tokenExchangeFailureStatus(
+        userFacingErrorMessage(error, 'Network error while contacting Spotify. Please try again.'),
       );
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -105,11 +114,11 @@ export class AuthFlow {
     localStorage.removeItem(this.#deps.storageKeys.verifier);
 
     if (!response.ok) {
-      this.#deps.setAuthStatus(
-        tokenExchangeFailureStatus(
-          spotifyStatusMessage(response.status, 'Network error while contacting Spotify. Please try again.'),
-        ),
+      const status = tokenExchangeFailureStatus(
+        spotifyStatusMessage(response.status, 'Network error while contacting Spotify. Please try again.'),
       );
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -119,7 +128,9 @@ export class AuthFlow {
     try {
       data = /** @type {{access_token?: string; refresh_token?: string; expires_in?: number; scope?: string}} */ (await response.json());
     } catch {
-      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      const status = tokenExchangeFailureStatus('invalid token response');
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -128,7 +139,9 @@ export class AuthFlow {
       typeof data.expires_in === 'number' &&
       Number.isFinite(data.expires_in)
     )) {
-      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      const status = tokenExchangeFailureStatus('invalid token response');
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -167,6 +180,12 @@ export class AuthFlow {
   consumePendingRefreshFailureStatus() {
     const pendingStatus = this.#pendingRefreshFailureStatus;
     this.#pendingRefreshFailureStatus = null;
+    return pendingStatus;
+  }
+
+  consumePendingRedirectStatus() {
+    const pendingStatus = this.#pendingRedirectStatus;
+    this.#pendingRedirectStatus = null;
     return pendingStatus;
   }
 

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -36,7 +36,7 @@ function installBrowserState(href = 'http://127.0.0.1:4173/') {
   });
   Object.defineProperty(globalThis, 'history', {
     value: {
-      replaceState: (_data, _unused, url) => {
+      replaceState: (/** @type {unknown} */ _data, /** @type {string} */ _unused, /** @type {string} */ url) => {
         locationRef.href = url;
       },
     },
@@ -46,6 +46,12 @@ function installBrowserState(href = 'http://127.0.0.1:4173/') {
   return locationRef;
 }
 
+/**
+ * @param {{
+ *   reportError?: (error: unknown, options: { context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string; }) => void;
+ *   setAuthStatus?: (message: string) => void;
+ * }} [options]
+ */
 function createAuthFlow({ reportError = () => {}, setAuthStatus = () => {} } = {}) {
   return new AuthFlow({
     scopes: ['a'],
@@ -118,6 +124,7 @@ test('handleAuthRedirect records an authorization error, clears the verifier, an
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?error=access_denied');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -136,6 +143,7 @@ test('handleAuthRedirect reports a missing verifier and clears the handled code 
   installLocalStorage();
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -154,6 +162,7 @@ test('handleAuthRedirect reports exchange failures, clears the verifier, and rem
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -176,6 +185,7 @@ test('handleAuthRedirect reports invalid token responses after a successful exch
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {


### PR DESCRIPTION
### Motivation
- Redirect-based OAuth failures (authorization error, missing PKCE verifier, token exchange failures) were being overwritten during app startup, losing the explicit user-facing message.
- The startup auth rendering needs to prefer any redirect-related status so the user sees the exact redirect error instead of a generic refresh/startup message.

### Description
- Add a dedicated pending redirect status channel to `AuthFlow` (`#pendingRedirectStatus`) and expose it via `consumePendingRedirectStatus()` so redirect errors are preserved across `handleAuthRedirect()` and bootstrap. (`src/core/auth-flow.js`)
- Set `#pendingRedirectStatus` for all redirect-related failures (auth error, missing verifier, fetch/network and token exchange failures) and still render the message immediately via the existing `setAuthStatus` callback. (`src/core/auth-flow.js`)
- Update `refreshStartupAuthStatus()` to check `authFlow.consumePendingRedirectStatus()` before refresh-failure and generic status resolution so redirect errors are displayed on startup. (`src/app.js`)
- Add JSDoc typing annotations to `tests/unit/auth-flow.test.js` to restore strict type coverage expected by `npm run check`. (`tests/unit/auth-flow.test.js`)

### Testing
- Ran `npm run check` and it completed successfully (type coverage and checks passed). 
- Ran `npx playwright test tests/ui/auth-ui.spec.js` and the app-side redirect scenarios now behave correctly; the Playwright suite in this environment reports all auth redirect cases passing but one UI test still fails due to the test helper using `RegExp.escape`, which is not available in this Node runtime (Node 20) and is unrelated to the app code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5748d53608321859734359b8476a0)