### PR TITLE
Special-case access_denied OAuth redirect in auth flow

### DIFF
--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -64,7 +64,9 @@ export class AuthFlow {
     };
 
     if (error) {
-      const status = `Spotify authorization error: ${error}`;
+      const status = error === 'access_denied'
+        ? 'Spotify authorization denied.'
+        : `Spotify authorization error: ${error}`;
       this.#pendingRedirectStatus = status;
       this.#deps.setAuthStatus(status);
       localStorage.removeItem(this.#deps.storageKeys.verifier);

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -134,7 +134,7 @@ test('handleAuthRedirect records an authorization error, clears the verifier, an
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Spotify authorization error: access_denied']);
+  assert.deepEqual(statuses, ['Spotify authorization denied.']);
   assert.equal(globalThis.localStorage.getItem('v'), null);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
 });


### PR DESCRIPTION
### Motivation
- Make the user-facing message clearer when Spotify returns `error=access_denied` on OAuth redirect by showing `Spotify authorization denied.` instead of a generic `Spotify authorization error: access_denied`.

### Description
- Update `src/core/auth-flow.js` to special-case `access_denied` and set the auth status to `Spotify authorization denied.`, and update the unit test `tests/unit/auth-flow.test.js` to match the new expected message.

### Testing
- Ran `npm run test:ui -- tests/ui/auth-ui.spec.js` which passed all tests (10 passed).
- Ran `npm run check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6820075888321a2930b99ef3fadaa)