### PR TITLE
Fix up Spotify OAuth callback handling

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,11 +3,15 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/ui',
   fullyParallel: true,
+  timeout: 1_000_000,
   use: {
     baseURL: 'http://127.0.0.1:4173',
     browserName: 'chromium',
     serviceWorkers: 'block',
     trace: 'on-first-retry',
+    launchOptions: {
+      // slowMo: 10_000,
+    },
   },
   webServer: {
     command: 'node scripts/serve-static.js',

--- a/src/app.js
+++ b/src/app.js
@@ -318,11 +318,18 @@ function refreshAuthStatus() {
 }
 
 function refreshStartupAuthStatus() {
+  const redirectStatus = authFlow.consumePendingRedirectStatus();
+  if (redirectStatus && !getToken()) {
+    setAuthStatus(redirectStatus);
+    return;
+  }
+
   const refreshFailureStatus = authFlow.consumePendingRefreshFailureStatus();
   if (refreshFailureStatus && !getToken()) {
     setAuthStatus(refreshFailureStatus);
     return;
   }
+
   refreshAuthStatus();
 }
 

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -64,7 +64,9 @@ export class AuthFlow {
     };
 
     if (error) {
-      const status = `Spotify authorization error: ${error}`;
+      const status = error === 'access_denied'
+        ? 'Spotify authorization denied.'
+        : `Spotify authorization error: ${error}`;
       this.#pendingRedirectStatus = status;
       this.#deps.setAuthStatus(status);
       localStorage.removeItem(this.#deps.storageKeys.verifier);

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -1,3 +1,6 @@
+import { spotifyStatusMessage } from '../spotify-status-message.js';
+import { userFacingErrorMessage } from './error-reporter.js';
+
 /**
  * @typedef AuthFlowDeps
  * @property {string[]} scopes
@@ -49,11 +52,16 @@ export class AuthFlow {
     const url = new URL(locationRef.href);
     const code = url.searchParams.get('code');
     const error = url.searchParams.get('error');
+    const clearHandledRedirectUrl = () => {
+      url.searchParams.delete('code');
+      url.searchParams.delete('error');
+      historyRef.replaceState({}, '', url.toString());
+    };
 
     if (error) {
       this.#deps.setAuthStatus(`Spotify authorization error: ${error}`);
-      url.searchParams.delete('error');
-      historyRef.replaceState({}, '', url.toString());
+      localStorage.removeItem(this.#deps.storageKeys.verifier);
+      clearHandledRedirectUrl();
       return;
     }
 
@@ -63,6 +71,7 @@ export class AuthFlow {
 
     if (!verifier) {
       this.#deps.setAuthStatus('Missing PKCE verifier. Try connecting again.');
+      clearHandledRedirectUrl();
       return;
     }
 
@@ -74,29 +83,63 @@ export class AuthFlow {
       code_verifier: verifier,
     });
 
-    const response = await fetch('https://accounts.spotify.com/api/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: formData,
-    });
-
-    if (!response.ok) {
-      this.#deps.setAuthStatus('Failed to exchange Spotify code for token.');
+    /** @type {Response} */
+    let response;
+    try {
+      response = await fetch('https://accounts.spotify.com/api/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData,
+      });
+    } catch (error) {
+      localStorage.removeItem(this.#deps.storageKeys.verifier);
+      this.#deps.setAuthStatus(
+        tokenExchangeFailureStatus(
+          userFacingErrorMessage(error, 'Network error while contacting Spotify. Please try again.'),
+        ),
+      );
+      clearHandledRedirectUrl();
       return;
     }
 
-    /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */
-    const data = /** @type {{access_token: string; refresh_token?: string; expires_in: number; scope?: string}} */ (await response.json());
+    localStorage.removeItem(this.#deps.storageKeys.verifier);
+
+    if (!response.ok) {
+      this.#deps.setAuthStatus(
+        tokenExchangeFailureStatus(
+          spotifyStatusMessage(response.status, 'Network error while contacting Spotify. Please try again.'),
+        ),
+      );
+      clearHandledRedirectUrl();
+      return;
+    }
+
+    /** @type {{access_token?: string; refresh_token?: string; expires_in?: number; scope?: string}} */
+    let data;
+    try {
+      data = /** @type {{access_token?: string; refresh_token?: string; expires_in?: number; scope?: string}} */ (await response.json());
+    } catch {
+      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      clearHandledRedirectUrl();
+      return;
+    }
+    if (!(
+      typeof data.access_token === 'string' &&
+      typeof data.expires_in === 'number' &&
+      Number.isFinite(data.expires_in)
+    )) {
+      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      clearHandledRedirectUrl();
+      return;
+    }
     localStorage.setItem(this.#deps.storageKeys.token, data.access_token);
     if (data.refresh_token) {
       localStorage.setItem(this.#deps.storageKeys.refreshToken, data.refresh_token);
     }
     localStorage.setItem(this.#deps.storageKeys.tokenExpiry, String(Date.now() + data.expires_in * 1000));
     localStorage.setItem(this.#deps.storageKeys.tokenScope, data.scope ?? '');
-    localStorage.removeItem(this.#deps.storageKeys.verifier);
 
-    url.searchParams.delete('code');
-    historyRef.replaceState({}, '', url.toString());
+    clearHandledRedirectUrl();
   }
 
   clearAuth() {
@@ -222,4 +265,16 @@ async function codeChallengeFromVerifier(verifier) {
   for (const byte of bytes) str += String.fromCharCode(byte);
 
   return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+
+/** @param {string} detail */
+function tokenExchangeFailureStatus(detail) {
+  return `Spotify token exchange failed: ${ensureTrailingPeriod(detail)}`;
+}
+
+/** @param {string} message */
+function ensureTrailingPeriod(message) {
+  const trimmed = message.trim().replace(/[.!?]+$/u, '');
+  return `${trimmed}.`;
 }

--- a/src/core/auth-flow.js
+++ b/src/core/auth-flow.js
@@ -15,10 +15,13 @@ export class AuthFlow {
   #deps;
   /** @type {string | null} */
   #pendingRefreshFailureStatus;
+  /** @type {string | null} */
+  #pendingRedirectStatus;
   /** @param {AuthFlowDeps} deps */
   constructor(deps) {
     this.#deps = deps;
     this.#pendingRefreshFailureStatus = null;
+    this.#pendingRedirectStatus = null;
   }
 
   async startLogin() {
@@ -43,6 +46,8 @@ export class AuthFlow {
   }
 
   async handleAuthRedirect() {
+    this.#pendingRedirectStatus = null;
+
     const locationRef = /** @type {{origin: string; pathname: string; href: string}} */ (
       /** @type {unknown} */ (Reflect.get(globalThis, 'location'))
     );
@@ -59,7 +64,9 @@ export class AuthFlow {
     };
 
     if (error) {
-      this.#deps.setAuthStatus(`Spotify authorization error: ${error}`);
+      const status = `Spotify authorization error: ${error}`;
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       localStorage.removeItem(this.#deps.storageKeys.verifier);
       clearHandledRedirectUrl();
       return;
@@ -70,7 +77,9 @@ export class AuthFlow {
     const verifier = localStorage.getItem(this.#deps.storageKeys.verifier);
 
     if (!verifier) {
-      this.#deps.setAuthStatus('Missing PKCE verifier. Try connecting again.');
+      const status = 'Missing PKCE verifier. Try connecting again.';
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -93,11 +102,11 @@ export class AuthFlow {
       });
     } catch (error) {
       localStorage.removeItem(this.#deps.storageKeys.verifier);
-      this.#deps.setAuthStatus(
-        tokenExchangeFailureStatus(
-          userFacingErrorMessage(error, 'Network error while contacting Spotify. Please try again.'),
-        ),
+      const status = tokenExchangeFailureStatus(
+        userFacingErrorMessage(error, 'Network error while contacting Spotify. Please try again.'),
       );
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -105,11 +114,11 @@ export class AuthFlow {
     localStorage.removeItem(this.#deps.storageKeys.verifier);
 
     if (!response.ok) {
-      this.#deps.setAuthStatus(
-        tokenExchangeFailureStatus(
-          spotifyStatusMessage(response.status, 'Network error while contacting Spotify. Please try again.'),
-        ),
+      const status = tokenExchangeFailureStatus(
+        spotifyStatusMessage(response.status, 'Network error while contacting Spotify. Please try again.'),
       );
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -119,7 +128,9 @@ export class AuthFlow {
     try {
       data = /** @type {{access_token?: string; refresh_token?: string; expires_in?: number; scope?: string}} */ (await response.json());
     } catch {
-      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      const status = tokenExchangeFailureStatus('invalid token response');
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -128,7 +139,9 @@ export class AuthFlow {
       typeof data.expires_in === 'number' &&
       Number.isFinite(data.expires_in)
     )) {
-      this.#deps.setAuthStatus(tokenExchangeFailureStatus('invalid token response'));
+      const status = tokenExchangeFailureStatus('invalid token response');
+      this.#pendingRedirectStatus = status;
+      this.#deps.setAuthStatus(status);
       clearHandledRedirectUrl();
       return;
     }
@@ -167,6 +180,12 @@ export class AuthFlow {
   consumePendingRefreshFailureStatus() {
     const pendingStatus = this.#pendingRefreshFailureStatus;
     this.#pendingRefreshFailureStatus = null;
+    return pendingStatus;
+  }
+
+  consumePendingRedirectStatus() {
+    const pendingStatus = this.#pendingRedirectStatus;
+    this.#pendingRedirectStatus = null;
     return pendingStatus;
   }
 

--- a/tests/ui/auth-ui.spec.js
+++ b/tests/ui/auth-ui.spec.js
@@ -133,7 +133,7 @@ test.describe('Auth and Connection States', () => {
     );
   });
 
-  test('Auth redirect with error clears query and records disconnected auth state', async ({ context, page, ui }) => {
+  test('Auth redirect with error clears query and records an explicit auth error state', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
     });
@@ -141,18 +141,18 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/?error=access_denied');
 
     await expect(page).toHaveURL('/');
-    await expect(ui.auth.status).toHaveText('Not connected.');
+    await expect(ui.auth.status).toHaveText('Spotify authorization error: access_denied');
   });
 
-  test('Auth redirect with code and missing verifier keeps code and leaves session disconnected', async ({ context, page, ui }) => {
+  test('Auth redirect with code and missing verifier clears the code and records the missing verifier state', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
     });
 
     await page.goto('/?code=abc123');
 
-    await expect(page).toHaveURL('/?code=abc123');
-    await expect(ui.auth.status).toHaveText('Not connected.');
+    await expect(page).toHaveURL('/');
+    await expect(ui.auth.status).toHaveText('Missing PKCE verifier. Try connecting again.');
   });
 
   test('Successful code exchange stores tokens, clears verifier, and removes code from the URL', async ({ context, page, ui }) => {
@@ -198,7 +198,7 @@ test.describe('Auth and Connection States', () => {
     expect(authState.verifier).toBeNull();
   });
 
-  test('Failed code exchange attempts token request and keeps code in URL', async ({ context, page, ui }) => {
+  test('Failed code exchange clears the code, clears the verifier, and records the exchange failure', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
       localStorage.setItem('shuffle-by-album.pkceVerifier', 'verifier');
@@ -213,8 +213,12 @@ test.describe('Auth and Connection States', () => {
 
     await page.goto('/?code=abc123');
 
-    await expect(page).toHaveURL('/?code=abc123');
-    await expect(ui.auth.status).toHaveText('Not connected.');
+    await expect(page).toHaveURL('/');
+    await expect(ui.auth.status).toHaveText(
+      'Spotify token exchange failed: Network error while contacting Spotify. Please try again.',
+    );
+    const verifier = await page.evaluate(() => localStorage.getItem('shuffle-by-album.pkceVerifier'));
+    expect(verifier).toBeNull();
     expect(requests).toHaveLength(1);
   });
 });

--- a/tests/ui/auth-ui.spec.js
+++ b/tests/ui/auth-ui.spec.js
@@ -133,7 +133,7 @@ test.describe('Auth and Connection States', () => {
     );
   });
 
-  test('Auth redirect with error clears query and reports an explicit auth error', async ({ context, page, ui }) => {
+  test('Auth redirect with `access_denied` clears query and reports authorization denied', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
     });
@@ -141,7 +141,18 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/?error=access_denied');
 
     await expect(page).toHaveURL('/');
-    await expect(ui.auth.status).toHaveText('Spotify authorization error: access_denied');
+    await expect(ui.auth.status).toHaveText('Spotify authorization denied.');
+  });
+
+  test('Auth redirect with other error clears query and reports an explicit auth error', async ({ context, page, ui }) => {
+    await context.addInitScript(() => {
+      localStorage.clear();
+    });
+
+    await page.goto('/?error=unauthorized_client');
+
+    await expect(page).toHaveURL('/');
+    await expect(ui.auth.status).toHaveText('Spotify authorization error: unauthorized_client');
   });
 
   test('Auth redirect with code and missing verifier clears the code and reports the missing verifier', async ({ context, page, ui }) => {

--- a/tests/ui/auth-ui.spec.js
+++ b/tests/ui/auth-ui.spec.js
@@ -133,7 +133,7 @@ test.describe('Auth and Connection States', () => {
     );
   });
 
-  test('Auth redirect with error clears query and records an explicit auth error state', async ({ context, page, ui }) => {
+  test('Auth redirect with error clears query and reports an explicit auth error', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
     });
@@ -144,7 +144,7 @@ test.describe('Auth and Connection States', () => {
     await expect(ui.auth.status).toHaveText('Spotify authorization error: access_denied');
   });
 
-  test('Auth redirect with code and missing verifier clears the code and records the missing verifier state', async ({ context, page, ui }) => {
+  test('Auth redirect with code and missing verifier clears the code and reports the missing verifier', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
     });
@@ -198,7 +198,7 @@ test.describe('Auth and Connection States', () => {
     expect(authState.verifier).toBeNull();
   });
 
-  test('Failed code exchange clears the code, clears the verifier, and records the exchange failure', async ({ context, page, ui }) => {
+  test('Failed code exchange clears the code, clears the verifier, and reports the exchange failure', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       localStorage.clear();
       localStorage.setItem('shuffle-by-album.pkceVerifier', 'verifier');

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -134,7 +134,7 @@ test('handleAuthRedirect records an authorization error, clears the verifier, an
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Spotify authorization error: access_denied']);
+  assert.deepEqual(statuses, ['Spotify authorization denied.']);
   assert.equal(globalThis.localStorage.getItem('v'), null);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
 });

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -23,7 +23,30 @@ function installLocalStorage() {
   return store;
 }
 
-function createAuthFlow(reportError = () => {}) {
+function installBrowserState(href = 'http://127.0.0.1:4173/') {
+  const locationRef = {
+    origin: 'http://127.0.0.1:4173',
+    pathname: '/',
+    href,
+  };
+  Object.defineProperty(globalThis, 'location', {
+    value: locationRef,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'history', {
+    value: {
+      replaceState: (_data, _unused, url) => {
+        locationRef.href = url;
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+  return locationRef;
+}
+
+function createAuthFlow({ reportError = () => {}, setAuthStatus = () => {} } = {}) {
   return new AuthFlow({
     scopes: ['a'],
     spotifyAppId: 'id',
@@ -35,7 +58,7 @@ function createAuthFlow(reportError = () => {}) {
       tokenScope: 's',
     },
     reportError,
-    setAuthStatus: () => {},
+    setAuthStatus,
   });
 }
 
@@ -72,8 +95,10 @@ test('refreshSpotifyAccessToken reports network failures and returns null', asyn
   store.set('r', 'refresh-token');
 
   let reported = false;
-  const authFlow = createAuthFlow(() => {
-    reported = true;
+  const authFlow = createAuthFlow({
+    reportError: () => {
+      reported = true;
+    },
   });
 
   const fetchMock = mock.method(globalThis, 'fetch', async () => {
@@ -84,5 +109,86 @@ test('refreshSpotifyAccessToken reports network failures and returns null', asyn
 
   assert.equal(token, null);
   assert.equal(reported, true);
+  fetchMock.mock.restore();
+});
+
+
+test('handleAuthRedirect records an authorization error, clears the verifier, and removes the query', async () => {
+  const store = installLocalStorage();
+  store.set('v', 'verifier');
+  installBrowserState('http://127.0.0.1:4173/?error=access_denied');
+
+  const statuses = [];
+  const authFlow = createAuthFlow({
+    setAuthStatus: (message) => {
+      statuses.push(message);
+    },
+  });
+
+  await authFlow.handleAuthRedirect();
+
+  assert.deepEqual(statuses, ['Spotify authorization error: access_denied']);
+  assert.equal(globalThis.localStorage.getItem('v'), null);
+  assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
+});
+
+test('handleAuthRedirect reports a missing verifier and clears the handled code from the URL', async () => {
+  installLocalStorage();
+  installBrowserState('http://127.0.0.1:4173/?code=abc123');
+
+  const statuses = [];
+  const authFlow = createAuthFlow({
+    setAuthStatus: (message) => {
+      statuses.push(message);
+    },
+  });
+
+  await authFlow.handleAuthRedirect();
+
+  assert.deepEqual(statuses, ['Missing PKCE verifier. Try connecting again.']);
+  assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
+});
+
+test('handleAuthRedirect reports exchange failures, clears the verifier, and removes the handled code', async () => {
+  const store = installLocalStorage();
+  store.set('v', 'verifier');
+  installBrowserState('http://127.0.0.1:4173/?code=abc123');
+
+  const statuses = [];
+  const authFlow = createAuthFlow({
+    setAuthStatus: (message) => {
+      statuses.push(message);
+    },
+  });
+
+  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response('bad code', { status: 400 }));
+
+  await authFlow.handleAuthRedirect();
+
+  assert.deepEqual(statuses, ['Spotify token exchange failed: Network error while contacting Spotify. Please try again.']);
+  assert.equal(globalThis.localStorage.getItem('v'), null);
+  assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
+  fetchMock.mock.restore();
+});
+
+test('handleAuthRedirect reports invalid token responses after a successful exchange HTTP response', async () => {
+  const store = installLocalStorage();
+  store.set('v', 'verifier');
+  installBrowserState('http://127.0.0.1:4173/?code=abc123');
+
+  const statuses = [];
+  const authFlow = createAuthFlow({
+    setAuthStatus: (message) => {
+      statuses.push(message);
+    },
+  });
+
+  const fetchMock = mock.method(globalThis, 'fetch', async () => new Response(JSON.stringify({ expires_in: 3600 }), { status: 200 }));
+
+  await authFlow.handleAuthRedirect();
+
+  assert.deepEqual(statuses, ['Spotify token exchange failed: invalid token response.']);
+  assert.equal(globalThis.localStorage.getItem('v'), null);
+  assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
   fetchMock.mock.restore();
 });

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -36,7 +36,7 @@ function installBrowserState(href = 'http://127.0.0.1:4173/') {
   });
   Object.defineProperty(globalThis, 'history', {
     value: {
-      replaceState: (_data, _unused, url) => {
+      replaceState: (/** @type {unknown} */ _data, /** @type {string} */ _unused, /** @type {string} */ url) => {
         locationRef.href = url;
       },
     },
@@ -46,6 +46,12 @@ function installBrowserState(href = 'http://127.0.0.1:4173/') {
   return locationRef;
 }
 
+/**
+ * @param {{
+ *   reportError?: (error: unknown, options: { context: string; fallbackMessage: string; authStatusMessage?: string; toastMode?: 'always'|'cooldown'; toastKey?: string; }) => void;
+ *   setAuthStatus?: (message: string) => void;
+ * }} [options]
+ */
 function createAuthFlow({ reportError = () => {}, setAuthStatus = () => {} } = {}) {
   return new AuthFlow({
     scopes: ['a'],
@@ -118,6 +124,7 @@ test('handleAuthRedirect records an authorization error, clears the verifier, an
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?error=access_denied');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -136,6 +143,7 @@ test('handleAuthRedirect reports a missing verifier and clears the handled code 
   installLocalStorage();
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -154,6 +162,7 @@ test('handleAuthRedirect reports exchange failures, clears the verifier, and rem
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {
@@ -176,6 +185,7 @@ test('handleAuthRedirect reports invalid token responses after a successful exch
   store.set('v', 'verifier');
   installBrowserState('http://127.0.0.1:4173/?code=abc123');
 
+  /** @type {string[]} */
   const statuses = [];
   const authFlow = createAuthFlow({
     setAuthStatus: (message) => {


### PR DESCRIPTION
Make error cases match Android handling, except for `error=access_denied`, which shows a specific message