### PR TITLE
Fix npm check failures after storage transfer API updates

### DIFF
--- a/src/core/storage-transfer.js
+++ b/src/core/storage-transfer.js
@@ -70,6 +70,7 @@ export function importItemsData(raw, itemsStorageKey, removedItemsStorageKey) {
   if (!Array.isArray(maybeItems)) {
     return { ok: false, error: 'Import JSON must include a valid shuffle-by-album.items array.' };
   }
+  const parsedItems = /** @type {unknown[]} */ (maybeItems);
 
   const maybeRemovedItems = parsedObject[removedItemsStorageKey];
   if (maybeRemovedItems !== undefined && !Array.isArray(maybeRemovedItems)) {
@@ -95,7 +96,9 @@ export function importItemsData(raw, itemsStorageKey, removedItemsStorageKey) {
 
   return {
     ok: true,
-    items: maybeItems.filter(itemFilter),
-    removedItems: Array.isArray(maybeRemovedItems) ? maybeRemovedItems.filter(itemFilter) : [],
+    items: parsedItems.filter(itemFilter),
+    removedItems: Array.isArray(maybeRemovedItems)
+      ? /** @type {unknown[]} */ (maybeRemovedItems).filter(itemFilter)
+      : [],
   };
 }

--- a/tests/ui/storage-json-ui.spec.js
+++ b/tests/ui/storage-json-ui.spec.js
@@ -74,6 +74,7 @@ test.describe('Storage JSON Import/Export', () => {
     await expect(ui.removedItems.row('One')).toBeVisible();
 
     await ui.storage.exportDataButton.click();
+    /** @type {Record<string, unknown>} */
     const exported = JSON.parse(await ui.storage.json.inputValue());
     await expect(exported['shuffle-by-album.items']).toEqual([
       { type: 'album', uri: 'spotify:album:two', title: 'Two' },

--- a/tests/unit/item-store.test.js
+++ b/tests/unit/item-store.test.js
@@ -25,7 +25,10 @@ function installLocalStorage() {
 
 test('ItemStore normalizes import/get and supports remove/restore', () => {
   installLocalStorage();
-  const itemStore = new ItemStore({ items: 'shuffle-by-album.items' });
+  const itemStore = new ItemStore({
+    items: 'shuffle-by-album.items',
+    removedItems: 'shuffle-by-album.removedItems',
+  });
 
   const imported = itemStore.importFromJson(
     JSON.stringify({

--- a/tests/unit/storage-transfer.test.js
+++ b/tests/unit/storage-transfer.test.js
@@ -4,15 +4,24 @@ import assert from 'node:assert/strict';
 import { exportItemsData, importItemsData } from '#src/core/storage-transfer.js';
 
 test('exportItemsData exports parsed items or empty array', () => {
-  const exported = exportItemsData('[{"type":"album","uri":"spotify:album:a"}]', 'shuffle-by-album.items');
+  const exported = exportItemsData(
+    '[{"type":"album","uri":"spotify:album:a"}]',
+    'shuffle-by-album.items',
+    null,
+    'shuffle-by-album.removedItems',
+  );
   assert.equal(exported.error, null);
   assert.deepEqual(exported.data, {
     'shuffle-by-album.items': [{ type: 'album', uri: 'spotify:album:a' }],
+    'shuffle-by-album.removedItems': [],
   });
 
-  const empty = exportItemsData(null, 'shuffle-by-album.items');
+  const empty = exportItemsData(null, 'shuffle-by-album.items', null, 'shuffle-by-album.removedItems');
   assert.equal(empty.error, null);
-  assert.deepEqual(empty.data, { 'shuffle-by-album.items': [] });
+  assert.deepEqual(empty.data, {
+    'shuffle-by-album.items': [],
+    'shuffle-by-album.removedItems': [],
+  });
 });
 
 test('importItemsData validates shape and filters invalid entries', () => {
@@ -24,6 +33,7 @@ test('importItemsData validates shape and filters invalid entries', () => {
       ],
     }),
     'shuffle-by-album.items',
+    'shuffle-by-album.removedItems',
   );
 
   assert.equal(parsed.ok, true);
@@ -31,6 +41,6 @@ test('importItemsData validates shape and filters invalid entries', () => {
     assert.deepEqual(parsed.items, [{ type: 'album', uri: 'spotify:album:1', title: 'One' }]);
   }
 
-  const invalid = importItemsData('{"foo":[]}', 'shuffle-by-album.items');
+  const invalid = importItemsData('{"foo":[]}', 'shuffle-by-album.items', 'shuffle-by-album.removedItems');
   assert.equal(invalid.ok, false);
 });


### PR DESCRIPTION
### Motivation

- Restore passing `npm run check` after the storage transfer API and `ItemStore` constructor were updated to include a `removedItems` storage key and stricter type narrowing.

### Description

- Narrow the parsed items array in `importItemsData` by casting `maybeItems` to `unknown[]` and cast `maybeRemovedItems` when filtering to remove implicit-`any` and satisfy type coverage. 
- Update unit tests to pass the new `removedItems` storage key to `exportItemsData`/`importItemsData` and to assert the exported payload now includes `shuffle-by-album.removedItems`.
- Update the `ItemStore` unit test to construct `ItemStore` with both `items` and `removedItems` storage keys to match the constructor contract.
- Add an explicit type annotation in the UI spec for the parsed export JSON to avoid inferred `any` regressions in tests.

### Testing

- Ran `npm run check`, which executes the type checks and test suite, and the command completed successfully. 
- Existing unit and UI specs exercising storage import/export and item-store behavior passed under the check run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e92599401083218751b37848407a01)