### PR TITLE
Fix failing tests by aligning expected copy

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/ui',
   fullyParallel: true,
-  timeout: 1_000_000,
+  timeout: 20_000,
   use: {
     baseURL: 'http://127.0.0.1:4173',
     browserName: 'chromium',

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/ui',
   fullyParallel: true,
-  timeout: 20_000,
+  timeout: 1_000_000,
   use: {
     baseURL: 'http://127.0.0.1:4173',
     browserName: 'chromium',

--- a/tests/ui/auth-ui.spec.js
+++ b/tests/ui/auth-ui.spec.js
@@ -21,9 +21,9 @@ test.describe('Auth and Connection States', () => {
 
     await page.goto('/');
 
-    await expect(ui.auth.status).toHaveText('Not connected.');
+    await expect(ui.auth.status).toHaveText('Not connected');
     await ui.auth.disconnectButton.click();
-    await expect(ui.toasts.instance('Disconnected from Spotify.')).toBeVisible();
+    await expect(ui.toasts.instance('Disconnected from Spotify')).toBeVisible();
   });
 
   test('Connect button stores a PKCE verifier and redirects to Spotify authorize', async ({ context, page, ui }) => {
@@ -85,7 +85,7 @@ test.describe('Auth and Connection States', () => {
 
     await page.goto('/');
 
-    await expect(ui.auth.status).toHaveText('Connected.');
+    await expect(ui.auth.status).toHaveText('Connected');
 
     const authState = await page.evaluate(() => ({
       token: localStorage.getItem('shuffle-by-album.token'),
@@ -118,7 +118,7 @@ test.describe('Auth and Connection States', () => {
 
     await page.goto('/');
 
-    await expect(ui.auth.status).toHaveText('Unable to restore Spotify session. Please reconnect.');
+    await expect(ui.auth.status).toHaveText('Unable to restore Spotify session; please reconnect');
   });
 
   test('Missing playlist scopes shows reconnect warning', async ({ context, page, ui }) => {
@@ -129,7 +129,7 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/');
 
     await expect(ui.auth.status).toHaveText(
-      'Connected, but token is missing playlist import scopes. Disconnect and reconnect.',
+      'Connected, but token is missing playlist import scopes; disconnect and reconnect',
     );
   });
 
@@ -141,7 +141,7 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/?error=access_denied');
 
     await expect(page).toHaveURL('/');
-    await expect(ui.auth.status).toHaveText('Spotify authorization denied.');
+    await expect(ui.auth.status).toHaveText('Spotify authorization denied');
   });
 
   test('Auth redirect with other error clears query and reports an explicit auth error', async ({ context, page, ui }) => {
@@ -163,7 +163,7 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/?code=abc123');
 
     await expect(page).toHaveURL('/');
-    await expect(ui.auth.status).toHaveText('Missing PKCE verifier. Try connecting again.');
+    await expect(ui.auth.status).toHaveText('Missing PKCE verifier; try connecting again');
   });
 
   test('Successful code exchange stores tokens, clears verifier, and removes code from the URL', async ({ context, page, ui }) => {
@@ -190,7 +190,7 @@ test.describe('Auth and Connection States', () => {
     await page.goto('/?code=abc123');
 
     await expect(page).toHaveURL('/');
-    await expect(ui.auth.status).toHaveText('Connected.');
+    await expect(ui.auth.status).toHaveText('Connected');
 
     const authState = await page.evaluate(() => ({
       token: localStorage.getItem('shuffle-by-album.token'),
@@ -226,7 +226,7 @@ test.describe('Auth and Connection States', () => {
 
     await expect(page).toHaveURL('/');
     await expect(ui.auth.status).toHaveText(
-      'Spotify token exchange failed: Network error while contacting Spotify. Please try again.',
+      'Spotify token exchange failed: Network error while contacting Spotify; please try again',
     );
     const verifier = await page.evaluate(() => localStorage.getItem('shuffle-by-album.pkceVerifier'));
     expect(verifier).toBeNull();

--- a/tests/ui/detached-runtime-ui.spec.js
+++ b/tests/ui/detached-runtime-ui.spec.js
@@ -34,7 +34,7 @@ test.describe('Detached Session and Runtime Restore', () => {
     await page.goto('/');
     await ui.playback.startButton.click();
     await expect(ui.playback.status).toHaveText(
-      'Playback detached due to a Spotify error: Requested Spotify item or playback device was not found. device missing.',
+      'Playback detached due to a Spotify error: Requested Spotify item or playback device was not found device missing',
     );
     await expect(ui.playback.reattachButton).toBeVisible();
 
@@ -55,7 +55,7 @@ test.describe('Detached Session and Runtime Restore', () => {
     });
     await page.reload();
     await ui.playback.reattachButton.click();
-    await expect(ui.playback.status).toHaveText('Spotify session expired. Please reconnect.');
+    await expect(ui.playback.status).toHaveText('Spotify session expired; please reconnect');
   });
 
   test('Reattach with matched context resumes without restarting playback', async ({ context, page, ui }) => {
@@ -109,9 +109,9 @@ test.describe('Detached Session and Runtime Restore', () => {
     await ui.playback.reattachButton.click();
 
     await expect(ui.playback.status).toHaveText(
-      'Failed to reattach: Unable to check current Spotify playback (500): server busy.',
+      'Failed to reattach: Unable to check current Spotify playback (500): server busy',
     );
-    await expect(ui.toasts.instance('Failed to reattach.')).toBeVisible();
+    await expect(ui.toasts.instance('Failed to reattach')).toBeVisible();
     await expect(ui.playback.reattachButton).toBeVisible();
   });
 
@@ -153,7 +153,7 @@ test.describe('Detached Session and Runtime Restore', () => {
     await page.goto('/');
     await ui.playback.reattachButton.click();
 
-    await expect(ui.playback.status).toHaveText('Playback failed. Session stopped.');
+    await expect(ui.playback.status).toHaveText('Playback failed; session stopped');
   });
 
   test('Restores active runtime state and ignores invalid runtime JSON', async ({ context, page, ui }) => {
@@ -175,7 +175,7 @@ test.describe('Detached Session and Runtime Restore', () => {
       localStorage.setItem('shuffle-by-album.runtime', '{bad json');
     });
     await page.reload();
-    await expect(ui.auth.status).toHaveText('Connected.');
+    await expect(ui.auth.status).toHaveText('Connected');
     const runtimeValue = await page.evaluate(() => localStorage.getItem('shuffle-by-album.runtime'));
     expect(runtimeValue).toBeNull();
   });

--- a/tests/ui/item-add-ui.spec.js
+++ b/tests/ui/item-add-ui.spec.js
@@ -35,7 +35,7 @@ test.describe('Item Add', () => {
     await ui.savedItems.addButton.click();
 
     await expect(ui.savedItems.row('Road Trip Mix')).toBeVisible();
-    await expect(ui.toasts.instance('Added “Road Trip Mix”.')).toBeVisible();
+    await expect(ui.toasts.instance('Added “Road Trip Mix”')).toBeVisible();
   });
 
   test('Duplicate and invalid input show validation toasts', async ({ context, page, ui }) => {
@@ -45,11 +45,11 @@ test.describe('Item Add', () => {
 
     await ui.savedItems.uriInput.fill('not-valid');
     await ui.savedItems.addButton.click();
-    await expect(ui.toasts.instance('Enter a valid Spotify album/playlist URI or URL.')).toBeVisible();
+    await expect(ui.toasts.instance('Enter a valid Spotify album/playlist URI or URL')).toBeVisible();
 
     await ui.savedItems.uriInput.fill('spotify:album:album123');
     await ui.savedItems.addButton.click();
-    await expect(ui.toasts.instance('Item is already in your list.')).toBeVisible();
+    await expect(ui.toasts.instance('Item is already in your list')).toBeVisible();
   });
 
   test('Add while disconnected and title lookup failure both show toasts', async ({ context, page, ui }) => {
@@ -61,7 +61,7 @@ test.describe('Item Add', () => {
     await page.goto('/');
     await ui.savedItems.uriInput.fill('spotify:album:album123');
     await ui.savedItems.addButton.click();
-    await expect(ui.toasts.instance('Connect Spotify first so the app can load item titles.')).toBeVisible();
+    await expect(ui.toasts.instance('Connect Spotify first so the app can load item titles')).toBeVisible();
 
     installSpotifyRoutes(context, [
       {
@@ -74,6 +74,6 @@ test.describe('Item Add', () => {
     await page.reload();
     await ui.savedItems.uriInput.fill('spotify:album:missing');
     await ui.savedItems.addButton.click();
-    await expect(ui.toasts.instance('Unable to load title for that item. Please try another URI.')).toBeVisible();
+    await expect(ui.toasts.instance('Unable to load title for that item; please try another URI')).toBeVisible();
   });
 });

--- a/tests/ui/item-list-ui.spec.js
+++ b/tests/ui/item-list-ui.spec.js
@@ -34,10 +34,10 @@ test.describe('Item List', () => {
 
     await ui.savedItems.uriInput.fill('spotify:album:newone');
     await ui.savedItems.addButton.click();
-    await ui.toasts.instance('Added “New One”.').waitFor();
+    await ui.toasts.instance('Added “New One”').waitFor();
 
-    await ui.toasts.undoButton('Removed “A”.').click();
-    await expect(ui.toasts.instance('Restored “A”.')).toBeVisible();
+    await ui.toasts.undoButton('Removed “A”').click();
+    await expect(ui.toasts.instance('Restored “A”')).toBeVisible();
     await expect(ui.savedItems.row('A')).toBeVisible();
     await expect(ui.removedItems.section).toBeHidden();
     await expect(ui.savedItems.titles).toHaveText(['A', 'B', 'New One']);
@@ -47,12 +47,12 @@ test.describe('Item List', () => {
 
     await ui.savedItems.uriInput.fill('spotify:album:a');
     await ui.savedItems.addButton.click();
-    await expect(ui.toasts.instance('Added “A”.')).toBeVisible();
+    await expect(ui.toasts.instance('Added “A”')).toBeVisible();
     await expect(ui.removedItems.section).toBeHidden();
     await expect(ui.savedItems.titles).toHaveText(['B', 'New One', 'A']);
 
-    await ui.toasts.undoButton('Removed “A”.').click();
-    await expect(ui.toasts.instance('Item is already in your list.')).toBeVisible();
+    await ui.toasts.undoButton('Removed “A”').click();
+    await expect(ui.toasts.instance('Item is already in your list')).toBeVisible();
     await expect(ui.removedItems.section).toBeHidden();
   });
 
@@ -99,13 +99,13 @@ test.describe('Item List', () => {
 
     await ui.removedItems.restoreButton('A').click();
     await expect(ui.savedItems.row('A')).toBeVisible();
-    await expect(ui.toasts.instance('Restored “A”.')).toBeVisible();
+    await expect(ui.toasts.instance('Restored “A”')).toBeVisible();
     await expect(ui.savedItems.titles).toHaveText(['B', 'A']);
     await expect(ui.removedItems.count).toHaveText('1 item');
 
     await ui.savedItems.uriInput.fill('spotify:playlist:importme');
     await ui.savedItems.importAlbumsButton.click();
-    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found)')).toBeVisible();
     await expect(ui.savedItems.row('C')).toBeVisible();
     await expect(ui.savedItems.titles).toHaveText(['B', 'A', 'C']);
     await expect(ui.removedItems.section).toBeHidden();
@@ -140,7 +140,7 @@ test.describe('Item List', () => {
 
     await ui.removedItems.purgeButton.click();
     await ui.removedItems.confirmPurgeButton.click();
-    await expect(ui.toasts.instance('Purged Removed Items.')).toBeVisible();
+    await expect(ui.toasts.instance('Purged Removed Items')).toBeVisible();
     await expect(ui.removedItems.section).toBeHidden();
     await expect(ui.removedItems.purgeDialog).toBeHidden();
 

--- a/tests/ui/playback-monitor-ui.spec.js
+++ b/tests/ui/playback-monitor-ui.spec.js
@@ -131,7 +131,7 @@ test.describe('Playback Monitor Transitions', () => {
       if (typeof callback === 'function') await callback();
     });
     await expect(ui.playback.status).toHaveText(
-      'Spotify is playing a different album/playlist than this app expects. Reattach to resume.',
+      'Spotify is playing a different album/playlist than this app expects; reattach to resume',
     );
   });
 
@@ -184,8 +184,8 @@ test.describe('Playback Monitor Transitions', () => {
       if (typeof callback === 'function') await callback();
     });
 
-    await expect(ui.playback.status).toHaveText('Playback monitor encountered an error: Spotify rate limit reached. Please wait a moment and retry.');
-    await expect(ui.toasts.instance('Playback monitor encountered an error.')).toBeVisible();
+    await expect(ui.playback.status).toHaveText('Playback monitor encountered an error: Spotify rate limit reached; please wait a moment and retry');
+    await expect(ui.toasts.instance('Playback monitor encountered an error')).toBeVisible();
     await expect(ui.playback.reattachButton).toBeHidden();
     await expect(ui.playback.nextButton).toBeEnabled();
   });

--- a/tests/ui/playback-ui.spec.js
+++ b/tests/ui/playback-ui.spec.js
@@ -84,13 +84,13 @@ test.describe('Playback Controls', () => {
 
     await page.goto('/');
     await ui.playback.startButton.click();
-    await expect(ui.toasts.instance('Connect Spotify first.')).toBeVisible();
+    await expect(ui.toasts.instance('Connect Spotify first')).toBeVisible();
 
     await seedConnectedAuth(context);
 
     await page.reload();
     await ui.playback.startButton.click();
-    await expect(ui.toasts.instance('Add at least one album or playlist first.')).toBeVisible();
+    await expect(ui.toasts.instance('Add at least one album or playlist first')).toBeVisible();
 
     await seedItems(context, [
       { type: 'album', uri: 'spotify:album:one', title: 'One' },
@@ -127,11 +127,11 @@ test.describe('Playback Controls', () => {
     await ui.playback.nextButton.click();
     await expect(ui.playback.status).toHaveText('Now playing album 2 of 2: Two');
     await ui.playback.nextButton.click();
-    await expect(ui.playback.status).toHaveText('Finished: all selected albums/playlists were played.');
+    await expect(ui.playback.status).toHaveText('Finished: all selected albums/playlists were played');
 
     await ui.playback.startButton.click();
     await ui.playback.stopButton.click();
-    await expect(ui.playback.status).toHaveText('Session stopped.');
+    await expect(ui.playback.status).toHaveText('Session stopped');
   });
 
   test('Recoverable playback-start failure stops session instead of detaching', async ({ context, page, ui }) => {
@@ -161,7 +161,7 @@ test.describe('Playback Controls', () => {
     await page.goto('/');
     await ui.playback.startButton.click();
 
-    await expect(ui.playback.status).toHaveText('Playback failed. Session stopped.');
+    await expect(ui.playback.status).toHaveText('Playback failed; session stopped');
     await expect(ui.playback.reattachButton).toBeHidden();
   });
 });

--- a/tests/ui/playlist-import-ui.spec.js
+++ b/tests/ui/playlist-import-ui.spec.js
@@ -74,7 +74,7 @@ test.describe('Playlist Album Import', () => {
     await expect(ui.savedItems.row('Existing Album')).toBeVisible();
     await expect(ui.savedItems.row('New Album One')).toBeVisible();
     await expect(ui.savedItems.row('New Album Two')).toBeVisible();
-    await expect(ui.toasts.instance('Imported 2 album(s) from playlist (3 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 2 album(s) from playlist (3 unique album(s) found)')).toBeVisible();
     expect(requests.map((request) => request.url)).toEqual([
       'https://api.spotify.com/v1/playlists/playlist123/items?limit=50&offset=0&additional_types=track&market=from_token',
       'https://api.spotify.com/v1/playlists/playlist123/items?limit=50&offset=50&additional_types=track&market=from_token',
@@ -102,7 +102,7 @@ test.describe('Playlist Album Import', () => {
     await ui.savedItems.importAlbumsButton.click();
 
     await expect(ui.savedItems.row('New Album One')).toBeVisible();
-    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found)')).toBeVisible();
     expect(requests).toHaveLength(1);
     expect(requests[0].url).toBe(
       'https://api.spotify.com/v1/playlists/playlist123/items?limit=50&offset=0&additional_types=track&market=from_token',
@@ -130,7 +130,7 @@ test.describe('Playlist Album Import', () => {
     await ui.savedItems.importAlbumsButton.click();
 
     await expect(ui.savedItems.row('New Album Two')).toBeVisible();
-    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 1 album(s) from playlist (1 unique album(s) found)')).toBeVisible();
     expect(requests).toHaveLength(1);
     expect(requests[0].url).toBe(
       'https://api.spotify.com/v1/playlists/playlist123/items?limit=50&offset=0&additional_types=track&market=from_token',
@@ -145,7 +145,7 @@ test.describe('Playlist Album Import', () => {
     await page.goto('/');
     await ui.savedItems.uriInput.fill('playlist123');
     await ui.savedItems.importAlbumsButton.click();
-    await expect(ui.toasts.instance('Connect Spotify first so the app can import albums.')).toBeVisible();
+    await expect(ui.toasts.instance('Connect Spotify first so the app can import albums')).toBeVisible();
 
     await seedConnectedAuth(context);
 
@@ -163,15 +163,15 @@ test.describe('Playlist Album Import', () => {
     await page.reload();
     await ui.savedItems.uriInput.fill('$$$');
     await ui.savedItems.importAlbumsButton.click();
-    await expect(ui.toasts.instance('Enter a valid Spotify playlist URL, URI, or playlist ID.')).toBeVisible();
+    await expect(ui.toasts.instance('Enter a valid Spotify playlist URL, URI, or playlist ID')).toBeVisible();
 
     await ui.savedItems.uriInput.fill('playlist123');
     await ui.savedItems.importAlbumsButton.click();
-    await expect(ui.toasts.instance('Error importing albums: 500 boom.')).toBeVisible();
+    await expect(ui.toasts.instance('Error importing albums: 500 boom')).toBeVisible();
 
     await ui.savedItems.uriInput.fill('emptyplaylist');
     await ui.savedItems.importAlbumsButton.click();
-    await expect(ui.toasts.instance('Imported 0 album(s) from playlist (0 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 0 album(s) from playlist (0 unique album(s) found)')).toBeVisible();
   });
 
   test('Importing playlist with all albums already saved keeps list unchanged', async ({ context, page, ui }) => {
@@ -194,7 +194,7 @@ test.describe('Playlist Album Import', () => {
     await ui.savedItems.uriInput.fill('playlist123');
     await ui.savedItems.importAlbumsButton.click();
 
-    await expect(ui.toasts.instance('Imported 0 album(s) from playlist (1 unique album(s) found).')).toBeVisible();
+    await expect(ui.toasts.instance('Imported 0 album(s) from playlist (1 unique album(s) found)')).toBeVisible();
     await expect(ui.savedItems.row('Existing Album')).toHaveCount(1);
   });
 });

--- a/tests/unit/auth-flow.test.js
+++ b/tests/unit/auth-flow.test.js
@@ -91,7 +91,7 @@ test('refreshSpotifyAccessToken captures a validation failure status for non-ok 
   const token = await authFlow.refreshSpotifyAccessToken();
 
   assert.equal(token, null);
-  assert.equal(authFlow.consumePendingRefreshFailureStatus(), 'Unable to restore Spotify session. Please reconnect.');
+  assert.equal(authFlow.consumePendingRefreshFailureStatus(), 'Unable to restore Spotify session; please reconnect');
   assert.equal(authFlow.consumePendingRefreshFailureStatus(), null);
   fetchMock.mock.restore();
 });
@@ -134,7 +134,7 @@ test('handleAuthRedirect records an authorization error, clears the verifier, an
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Spotify authorization denied.']);
+  assert.deepEqual(statuses, ['Spotify authorization denied']);
   assert.equal(globalThis.localStorage.getItem('v'), null);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
 });
@@ -153,7 +153,7 @@ test('handleAuthRedirect reports a missing verifier and clears the handled code 
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Missing PKCE verifier. Try connecting again.']);
+  assert.deepEqual(statuses, ['Missing PKCE verifier; try connecting again']);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
 });
 
@@ -174,7 +174,7 @@ test('handleAuthRedirect reports exchange failures, clears the verifier, and rem
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Spotify token exchange failed: Network error while contacting Spotify. Please try again.']);
+  assert.deepEqual(statuses, ['Spotify token exchange failed: Network error while contacting Spotify; please try again']);
   assert.equal(globalThis.localStorage.getItem('v'), null);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
   fetchMock.mock.restore();
@@ -197,7 +197,7 @@ test('handleAuthRedirect reports invalid token responses after a successful exch
 
   await authFlow.handleAuthRedirect();
 
-  assert.deepEqual(statuses, ['Spotify token exchange failed: invalid token response.']);
+  assert.deepEqual(statuses, ['Spotify token exchange failed: invalid token response']);
   assert.equal(globalThis.localStorage.getItem('v'), null);
   assert.equal(globalThis.location.href, 'http://127.0.0.1:4173/');
   fetchMock.mock.restore();

--- a/tests/unit/spotify-status-message.test.js
+++ b/tests/unit/spotify-status-message.test.js
@@ -4,15 +4,15 @@ import assert from 'node:assert/strict';
 import { spotifyStatusMessage } from '#src/spotify-status-message.js';
 
 test('returns mapped message for known non-5xx Spotify statuses', () => {
-  assert.equal(spotifyStatusMessage(401, 'fallback'), 'Spotify session expired. Please reconnect.');
-  assert.equal(spotifyStatusMessage(403, 'fallback'), 'Spotify permissions are missing. Disconnect and reconnect.');
-  assert.equal(spotifyStatusMessage(404, 'fallback'), 'Requested Spotify item or playback device was not found.');
-  assert.equal(spotifyStatusMessage(429, 'fallback'), 'Spotify rate limit reached. Please wait a moment and retry.');
+  assert.equal(spotifyStatusMessage(401, 'fallback'), 'Spotify session expired; please reconnect');
+  assert.equal(spotifyStatusMessage(403, 'fallback'), 'Spotify permissions are missing; disconnect and reconnect');
+  assert.equal(spotifyStatusMessage(404, 'fallback'), 'Requested Spotify item or playback device was not found');
+  assert.equal(spotifyStatusMessage(429, 'fallback'), 'Spotify rate limit reached; please wait a moment and retry');
 });
 
 test('returns mapped message for 5xx statuses', () => {
-  assert.equal(spotifyStatusMessage(500, 'fallback'), 'Spotify is temporarily unavailable. Please try again shortly.');
-  assert.equal(spotifyStatusMessage(503, 'fallback'), 'Spotify is temporarily unavailable. Please try again shortly.');
+  assert.equal(spotifyStatusMessage(500, 'fallback'), 'Spotify is temporarily unavailable; please try again shortly');
+  assert.equal(spotifyStatusMessage(503, 'fallback'), 'Spotify is temporarily unavailable; please try again shortly');
 });
 
 test('returns fallback message for unmapped statuses', () => {


### PR DESCRIPTION
### Motivation
- The app’s user-facing copy changed (semicolon usage and removal of trailing periods), which caused a number of unit and Playwright UI assertions to fail.

### Description
- Updated unit test expectations in:
  - `tests/unit/auth-flow.test.js`
  - `tests/unit/spotify-status-message.test.js`
- Updated Playwright UI test expectations across:
  - `tests/ui/auth-ui.spec.js`
  - `tests/ui/detached-runtime-ui.spec.js`
  - `tests/ui/item-add-ui.spec.js`
  - `tests/ui/item-list-ui.spec.js`
  - `tests/ui/playback-monitor-ui.spec.js`
  - `tests/ui/playback-ui.spec.js`
  - `tests/ui/playlist-import-ui.spec.js`
- Changes are test-only; no runtime application logic was modified.

### Testing
- `npm test`
- `npm run test:ui`
- `npm run check`