### PR TITLE
Fix 204 response handling in player monitor

### DIFF
--- a/src/core/session-controller.js
+++ b/src/core/session-controller.js
@@ -141,7 +141,7 @@ export class SessionController {
     }
 
     const playerState = await this.#deps.spotifyAppApi.getPlayerState();
-    if (!playerState.ok) {
+    if (playerState.type === 'error') {
       if (this.#deps.isUnrecoverableSpotifyStatus(playerState.status)) {
         this.transitionToDetached(this.#deps.spotifyStatusMessage(playerState.status, 'Unable to reattach playback state'));
         return;
@@ -154,7 +154,7 @@ export class SessionController {
       );
     }
 
-    const contextUri = playerState.contextUri;
+    const contextUri = playerState.type === 'snapshot' ? playerState.contextUri : null;
 
     if (contextUri !== current.uri) {
       this.#session.activationState = 'active';

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -78,7 +78,7 @@ export class PlayerMonitor {
     }
 
     const playerState = await this.#deps.spotifyAppApi.getPlayerState();
-    if (!playerState.ok) {
+    if (playerState.type === 'error') {
       if (this.#deps.isUnrecoverableSpotifyStatus(playerState.status)) {
         this.#deps.transitionToDetached(
           spotifyStatusMessage(playerState.status, 'Spotify playback monitor detached'),
@@ -90,7 +90,7 @@ export class PlayerMonitor {
       return;
     }
 
-    if (playerState.type === 'no-content') {
+    if (playerState.type === 'no-snapshot-data') {
       return;
     }
 

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -90,6 +90,10 @@ export class PlayerMonitor {
       return;
     }
 
+    if (playerState.status === 204) {
+      return;
+    }
+
     const contextUri = playerState.contextUri;
 
     if (contextUri === session.currentUri) {

--- a/src/player-monitor.js
+++ b/src/player-monitor.js
@@ -90,7 +90,7 @@ export class PlayerMonitor {
       return;
     }
 
-    if (playerState.status === 204) {
+    if (playerState.type === 'no-content') {
       return;
     }
 

--- a/src/spotify-app-api.js
+++ b/src/spotify-app-api.js
@@ -3,10 +3,18 @@
 /** @typedef {'album' | 'playlist'} ItemType */
 
 /**
- * @typedef PlayerStateSuccess
+ * @typedef PlayerStateSnapshot
  * @property {true} ok
  * @property {number} status
+ * @property {'snapshot'} type
  * @property {string | null} contextUri
+ */
+
+/**
+ * @typedef PlayerStateNoContent
+ * @property {true} ok
+ * @property {204} status
+ * @property {'no-content'} type
  */
 
 /**
@@ -16,7 +24,7 @@
  * @property {string} errorText
  */
 
-/** @typedef {PlayerStateSuccess | PlayerStateFailure} PlayerStateResponse */
+/** @typedef {PlayerStateSnapshot | PlayerStateNoContent | PlayerStateFailure} PlayerStateResponse */
 
 /**
  * @typedef PlaylistAlbum
@@ -54,14 +62,14 @@ export class SpotifyAppApi {
   async getPlayerState() {
     const response = await this.#spotifyApi.request('/me/player', { method: 'GET' }, false);
     if (response.status === 204) {
-      return { ok: true, status: response.status, contextUri: null };
+      return { ok: true, status: 204, type: 'no-content' };
     }
     if (!response.ok) {
       return { ok: false, status: response.status, errorText: await response.text() };
     }
 
     const data = /** @type {{context?: {uri?: string} | null}} */ (await response.json());
-    return { ok: true, status: response.status, contextUri: data.context?.uri ?? null };
+    return { ok: true, status: response.status, type: 'snapshot', contextUri: data.context?.uri ?? null };
   }
 
   /** @returns {Promise<void>} */

--- a/src/spotify-app-api.js
+++ b/src/spotify-app-api.js
@@ -4,27 +4,25 @@
 
 /**
  * @typedef PlayerStateSnapshot
- * @property {true} ok
- * @property {number} status
  * @property {'snapshot'} type
+ * @property {number} status
  * @property {string | null} contextUri
  */
 
 /**
- * @typedef PlayerStateNoContent
- * @property {true} ok
+ * @typedef PlayerStateNoSnapshotData
+ * @property {'no-snapshot-data'} type
  * @property {204} status
- * @property {'no-content'} type
  */
 
 /**
- * @typedef PlayerStateFailure
- * @property {false} ok
+ * @typedef PlayerStateError
+ * @property {'error'} type
  * @property {number} status
  * @property {string} errorText
  */
 
-/** @typedef {PlayerStateSnapshot | PlayerStateNoContent | PlayerStateFailure} PlayerStateResponse */
+/** @typedef {PlayerStateSnapshot | PlayerStateNoSnapshotData | PlayerStateError} PlayerStateResponse */
 
 /**
  * @typedef PlaylistAlbum
@@ -62,14 +60,14 @@ export class SpotifyAppApi {
   async getPlayerState() {
     const response = await this.#spotifyApi.request('/me/player', { method: 'GET' }, false);
     if (response.status === 204) {
-      return { ok: true, status: 204, type: 'no-content' };
+      return { type: 'no-snapshot-data', status: 204 };
     }
     if (!response.ok) {
-      return { ok: false, status: response.status, errorText: await response.text() };
+      return { type: 'error', status: response.status, errorText: await response.text() };
     }
 
     const data = /** @type {{context?: {uri?: string} | null}} */ (await response.json());
-    return { ok: true, status: response.status, type: 'snapshot', contextUri: data.context?.uri ?? null };
+    return { type: 'snapshot', status: response.status, contextUri: data.context?.uri ?? null };
   }
 
   /** @returns {Promise<void>} */

--- a/tests/ui/playback-monitor-ui.spec.js
+++ b/tests/ui/playback-monitor-ui.spec.js
@@ -49,8 +49,8 @@ test.describe('Playback Monitor Transitions', () => {
         match: (request) => isSpotifyApiRequest(request, 'GET', '/me/player'),
         handle: (route) =>
           route.fulfill({
-            status: monitorState === 'null' ? 204 : 200,
-            ...(monitorState === 'null' ? { body: '' } : { json: { context: { uri: 'spotify:album:one' } } }),
+            status: 200,
+            json: monitorState === 'null' ? { context: null } : { context: { uri: 'spotify:album:one' } },
           }),
       },
     ]);
@@ -71,6 +71,71 @@ test.describe('Playback Monitor Transitions', () => {
       if (typeof callback === 'function') await callback();
     });
     await expect(ui.playback.status).toHaveText('Now playing album 2 of 2: Two');
+  });
+
+  test('Monitor ignores 204 playback snapshots after observing current context', async ({ context, page, ui }) => {
+    await context.addInitScript(() => {
+      /** @type {Array<() => void>} */
+      const callbacks = [];
+      /** @type {TestGlobal} */ (globalThis).__monitorCallbacks = callbacks;
+      window.setInterval =
+        /** @type {typeof window.setInterval} */
+        ((/** @type {TimerHandler} */ handler) => {
+          if (typeof handler === 'function') {
+            callbacks.push(() => handler());
+          }
+          return /** @type {unknown} */ (callbacks.length);
+        });
+      window.clearInterval = () => {};
+      Math.random = () => 0.999;
+    });
+
+    await seedItems(context, [
+      { type: 'album', uri: 'spotify:album:one', title: 'One' },
+      { type: 'album', uri: 'spotify:album:two', title: 'Two' },
+    ]);
+
+    let monitorState = 'match-one';
+    installSpotifyRoutes(context, [
+      {
+        match: (request) => isSpotifyApiRequest(request, 'PUT', '/me/player/shuffle'),
+        handle: (route) => route.fulfill({ status: 204, body: '' }),
+      },
+      {
+        match: (request) => isSpotifyApiRequest(request, 'PUT', '/me/player/repeat'),
+        handle: (route) => route.fulfill({ status: 204, body: '' }),
+      },
+      {
+        match: (request) => isSpotifyApiRequest(request, 'PUT', '/me/player/play'),
+        handle: (route) => route.fulfill({ status: 204, body: '' }),
+      },
+      {
+        match: (request) => isSpotifyApiRequest(request, 'GET', '/me/player'),
+        handle: (route) =>
+          route.fulfill(
+            monitorState === 'no-content'
+              ? { status: 204, body: '' }
+              : { status: 200, json: { context: { uri: 'spotify:album:one' } } },
+          ),
+      },
+    ]);
+
+    await page.goto('/');
+    await ui.playback.startButton.click();
+    await expect(ui.playback.status).toHaveText('Now playing album 1 of 2: One');
+
+    await page.evaluate(async () => {
+      const callback = /** @type {TestGlobal} */ (globalThis).__monitorCallbacks[0];
+      if (typeof callback === 'function') await callback();
+    });
+    await page.waitForTimeout(100);
+
+    monitorState = 'no-content';
+    await page.evaluate(async () => {
+      const callback = /** @type {TestGlobal} */ (globalThis).__monitorCallbacks[0];
+      if (typeof callback === 'function') await callback();
+    });
+    await expect(ui.playback.status).toHaveText('Now playing album 1 of 2: One');
   });
 
   test('Monitor mismatch detaches session with mismatch message', async ({ context, page, ui }) => {

--- a/tests/ui/playback-monitor-ui.spec.js
+++ b/tests/ui/playback-monitor-ui.spec.js
@@ -73,7 +73,7 @@ test.describe('Playback Monitor Transitions', () => {
     await expect(ui.playback.status).toHaveText('Now playing album 2 of 2: Two');
   });
 
-  test('Monitor ignores 204 playback snapshots after observing current context', async ({ context, page, ui }) => {
+  test('Monitor ignores 204 playback snapshots', async ({ context, page, ui }) => {
     await context.addInitScript(() => {
       /** @type {Array<() => void>} */
       const callbacks = [];
@@ -95,7 +95,7 @@ test.describe('Playback Monitor Transitions', () => {
       { type: 'album', uri: 'spotify:album:two', title: 'Two' },
     ]);
 
-    let monitorState = 'match-one';
+    let monitorState = 'no-content';
     installSpotifyRoutes(context, [
       {
         match: (request) => isSpotifyApiRequest(request, 'PUT', '/me/player/shuffle'),
@@ -129,6 +129,15 @@ test.describe('Playback Monitor Transitions', () => {
       if (typeof callback === 'function') await callback();
     });
     await page.waitForTimeout(100);
+    await expect(ui.playback.status).toHaveText('Now playing album 1 of 2: One');
+
+    monitorState = 'match-one';
+    await page.evaluate(async () => {
+      const callback = /** @type {TestGlobal} */ (globalThis).__monitorCallbacks[0];
+      if (typeof callback === 'function') await callback();
+    });
+    await page.waitForTimeout(100);
+    await expect(ui.playback.status).toHaveText('Now playing album 1 of 2: One');
 
     monitorState = 'no-content';
     await page.evaluate(async () => {

--- a/tests/unit/player-monitor.test.js
+++ b/tests/unit/player-monitor.test.js
@@ -11,7 +11,10 @@ import { PlayerMonitor, PlayerMonitorStatusError } from '#src/player-monitor.js'
  *   currentUri?: string | null;
  *   observedCurrentContext?: boolean;
  *   token?: string | null;
- *   playerState?: {ok: true; contextUri: string | null} | {ok: false; status: number; errorText: string};
+ *   playerState?:
+ *     | {type: 'snapshot'; contextUri: string | null}
+ *     | {type: 'no-snapshot-data'}
+ *     | {type: 'error'; status: number; errorText: string};
  *   playerStateError?: Error;
  *   isUnrecoverable?: (status: number) => boolean;
  * }} [options]
@@ -39,7 +42,7 @@ function createMonitor(options = {}) {
     if (options.playerStateError) {
       throw options.playerStateError;
     }
-    return options.playerState ?? { ok: true, contextUri: session.currentUri };
+    return options.playerState ?? { type: 'snapshot', contextUri: session.currentUri };
   });
 
   const deps = /** @type {PlayerMonitorDeps} */ ({
@@ -116,7 +119,7 @@ test('monitor loop detaches when token is unavailable', async () => {
 
 test('monitor loop reports recoverable player-state status errors', async () => {
   const { monitor, reportedErrors } = createMonitor({
-    playerState: { ok: false, status: 429, errorText: 'slow down' },
+    playerState: { type: 'error', status: 429, errorText: 'slow down' },
     isUnrecoverable: () => false,
   });
 
@@ -132,7 +135,7 @@ test('monitor loop reports recoverable player-state status errors', async () => 
 test('monitor loop advances when observed context becomes null', async () => {
   const { monitor, spies } = createMonitor({
     observedCurrentContext: true,
-    playerState: { ok: true, contextUri: null },
+    playerState: { type: 'snapshot', contextUri: null },
   });
 
   await runMonitorCycle(monitor);

--- a/tests/unit/spotify-app-api.test.js
+++ b/tests/unit/spotify-app-api.test.js
@@ -25,20 +25,20 @@ function createAppApi(handler) {
   return { appApi, calls };
 }
 
-test('getPlayerState returns a no-content type for 204 responses', async () => {
+test('getPlayerState returns a no-snapshot-data type for 204 responses', async () => {
   const { appApi, calls } = createAppApi(async () => new Response(null, { status: 204 }));
 
   const state = await appApi.getPlayerState();
 
-  assert.deepEqual(state, { ok: true, status: 204, type: 'no-content' });
+  assert.deepEqual(state, { type: 'no-snapshot-data', status: 204 });
   assert.deepEqual(calls[0], { path: '/me/player', requestInit: { method: 'GET' }, throwOnError: false });
 });
 
-test('getPlayerState returns error payload for non-ok responses', async () => {
+test('getPlayerState returns an error type for non-ok responses', async () => {
   const { appApi } = createAppApi(async () => new Response('device unavailable', { status: 404 }));
 
   const state = await appApi.getPlayerState();
-  assert.deepEqual(state, { ok: false, status: 404, errorText: 'device unavailable' });
+  assert.deepEqual(state, { type: 'error', status: 404, errorText: 'device unavailable' });
 });
 
 test('getPlayerState returns a snapshot type with context uri from response body', async () => {
@@ -47,14 +47,14 @@ test('getPlayerState returns a snapshot type with context uri from response body
   );
 
   const state = await appApi.getPlayerState();
-  assert.deepEqual(state, { ok: true, status: 200, type: 'snapshot', contextUri: 'spotify:playlist:abc' });
+  assert.deepEqual(state, { type: 'snapshot', status: 200, contextUri: 'spotify:playlist:abc' });
 });
 
 test('getPlayerState returns a snapshot type with null context from response body', async () => {
   const { appApi } = createAppApi(async () => new Response('{"context":null}', { status: 200 }));
 
   const state = await appApi.getPlayerState();
-  assert.deepEqual(state, { ok: true, status: 200, type: 'snapshot', contextUri: null });
+  assert.deepEqual(state, { type: 'snapshot', status: 200, contextUri: null });
 });
 
 test('disableShuffle and disableRepeat call expected endpoints', async () => {

--- a/tests/unit/spotify-app-api.test.js
+++ b/tests/unit/spotify-app-api.test.js
@@ -25,12 +25,12 @@ function createAppApi(handler) {
   return { appApi, calls };
 }
 
-test('getPlayerState returns null context for 204 responses', async () => {
+test('getPlayerState returns a no-content type for 204 responses', async () => {
   const { appApi, calls } = createAppApi(async () => new Response(null, { status: 204 }));
 
   const state = await appApi.getPlayerState();
 
-  assert.deepEqual(state, { ok: true, status: 204, contextUri: null });
+  assert.deepEqual(state, { ok: true, status: 204, type: 'no-content' });
   assert.deepEqual(calls[0], { path: '/me/player', requestInit: { method: 'GET' }, throwOnError: false });
 });
 
@@ -41,13 +41,20 @@ test('getPlayerState returns error payload for non-ok responses', async () => {
   assert.deepEqual(state, { ok: false, status: 404, errorText: 'device unavailable' });
 });
 
-test('getPlayerState returns context uri from response body', async () => {
+test('getPlayerState returns a snapshot type with context uri from response body', async () => {
   const { appApi } = createAppApi(
     async () => new Response('{"context":{"uri":"spotify:playlist:abc"}}', { status: 200 }),
   );
 
   const state = await appApi.getPlayerState();
-  assert.deepEqual(state, { ok: true, status: 200, contextUri: 'spotify:playlist:abc' });
+  assert.deepEqual(state, { ok: true, status: 200, type: 'snapshot', contextUri: 'spotify:playlist:abc' });
+});
+
+test('getPlayerState returns a snapshot type with null context from response body', async () => {
+  const { appApi } = createAppApi(async () => new Response('{"context":null}', { status: 200 }));
+
+  const state = await appApi.getPlayerState();
+  assert.deepEqual(state, { ok: true, status: 200, type: 'snapshot', contextUri: null });
 });
 
 test('disableShuffle and disableRepeat call expected endpoints', async () => {


### PR DESCRIPTION
Ignore 204 player snapshots so the monitor only advances on 200 empty-context responses, and update the UI specs to cover the 200-null advance path plus the ignored-204 case

This still isn't quite the right way to handle auto-advance, but it's less wrong, and matches current albums-android handling