### PR TITLE
Add --cross-platform flag to scripts/ui-test-list

### DIFF
--- a/scripts/ui-test-list
+++ b/scripts/ui-test-list
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
+import argparse
 import fnmatch
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 SUITE_PATTERNS = [
@@ -177,7 +177,7 @@ def find_arrow_block_start(text: str, index: int, limit: int) -> int | None:
     return None
 
 
-def parse_suite_tests(path: str, text: str) -> list[tuple[str, str]]:
+def parse_suite_tests(path: str, text: str, *, cross_platform: bool = False) -> list[tuple[str, str]]:
     events: list[tuple[int, str, int]] = []
     for match in DESCRIBE_RE.finditer(text):
         events.append((match.start(), 'describe', match.end()))
@@ -214,8 +214,11 @@ def parse_suite_tests(path: str, text: str) -> list[tuple[str, str]]:
         suite_title = ' > '.join(suite_title for _, suite_title in describe_stack)
         if not suite_title:
             suite_title = '(root)'
-        base_filename = path.rsplit('/', 1)[-1]
-        suite_tests.append((f'{suite_title} [{base_filename}]:', title))
+        if cross_platform:
+            suite_tests.append((f'{suite_title}:', title))
+        else:
+            base_filename = path.rsplit('/', 1)[-1]
+            suite_tests.append((f'{suite_title} [{base_filename}]:', title))
 
     return suite_tests
 
@@ -233,7 +236,7 @@ def render_test_list(suite_tests: list[tuple[str, str]]) -> str:
     return ''.join(f'{line}\n' for line in lines)
 
 
-def suite_test_list(ref: str | None) -> str:
+def suite_test_list(ref: str | None, *, cross_platform: bool = False) -> str:
     if ref is None:
         root = repo_root()
         suite_files = list_working_copy_files(root)
@@ -241,7 +244,7 @@ def suite_test_list(ref: str | None) -> str:
         for path in suite_files:
             text = working_copy_file_at(root, path)
             if text is not None:
-                suite_tests.extend(parse_suite_tests(path, text))
+                suite_tests.extend(parse_suite_tests(path, text, cross_platform=cross_platform))
         return render_test_list(suite_tests)
 
     suite_files = list_ref_files(ref)
@@ -249,17 +252,24 @@ def suite_test_list(ref: str | None) -> str:
     for path in suite_files:
         text = ref_file_at(ref, path)
         if text is not None:
-            suite_tests.extend(parse_suite_tests(path, text))
+            suite_tests.extend(parse_suite_tests(path, text, cross_platform=cross_platform))
     return render_test_list(suite_tests)
 
 
-def main() -> int:
-    if len(sys.argv) > 2:
-        print(f'Usage: {sys.argv[0]} [ref]', file=sys.stderr)
-        return 1
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='List Playwright UI tests grouped by suite.')
+    parser.add_argument('ref', nargs='?', help='Git ref to list tests from instead of the working copy')
+    parser.add_argument(
+        '--cross-platform',
+        action='store_true',
+        help='Omit source filenames from suite headings for cross-platform output',
+    )
+    return parser.parse_args()
 
-    ref = sys.argv[1] if len(sys.argv) == 2 else None
-    print(suite_test_list(ref), end='')
+
+def main() -> int:
+    args = parse_args()
+    print(suite_test_list(args.ref, cross_platform=args.cross_platform), end='')
     return 0
 
 

--- a/scripts/ui-test-list-diff
+++ b/scripts/ui-test-list-diff
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 
+import argparse
 import difflib
 import subprocess
 import sys
 from pathlib import Path
 
 
-def ui_test_list(ref: str) -> list[str]:
+def ui_test_list(ref: str, *, cross_platform: bool = False) -> list[str]:
     script = Path(__file__).with_name('ui-test-list')
+    command = [sys.executable, str(script)]
+    if cross_platform:
+        command.append('--cross-platform')
+    command.append(ref)
     result = subprocess.run(
-        [sys.executable, str(script), ref],
+        command,
         check=True,
         capture_output=True,
         text=True,
@@ -90,22 +95,29 @@ def suite_aware_unified_diff(
     return diff_lines
 
 
-def main() -> int:
-    if len(sys.argv) != 3:
-        print(f'Usage: {sys.argv[0]} <base-ref> <head-ref>', file=sys.stderr)
-        return 1
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Show UI test list changes.')
+    parser.add_argument('base_ref', help='Base git ref to compare')
+    parser.add_argument('head_ref', help='Head git ref to compare')
+    parser.add_argument(
+        '--cross-platform',
+        action='store_true',
+        help='Forward --cross-platform to ui-test-list for normalized suite headings',
+    )
+    return parser.parse_args()
 
-    base_ref = sys.argv[1]
-    head_ref = sys.argv[2]
-    base_lines = ui_test_list(base_ref)
-    head_lines = ui_test_list(head_ref)
+
+def main() -> int:
+    args = parse_args()
+    base_lines = ui_test_list(args.base_ref, cross_platform=args.cross_platform)
+    head_lines = ui_test_list(args.head_ref, cross_platform=args.cross_platform)
 
     diff = ''.join(
         suite_aware_unified_diff(
             base_lines,
             head_lines,
-            fromfile=f'{base_ref} test-list',
-            tofile=f'{head_ref} test-list',
+            fromfile=f'{args.base_ref} test-list',
+            tofile=f'{args.head_ref} test-list',
             n=1,
         )
     )

--- a/scripts/ui-test-list-diff
+++ b/scripts/ui-test-list-diff
@@ -7,12 +7,13 @@ import sys
 from pathlib import Path
 
 
-def ui_test_list(ref: str, *, cross_platform: bool = False) -> list[str]:
+def ui_test_list(ref: str | None, *, cross_platform: bool = False) -> list[str]:
     script = Path(__file__).with_name('ui-test-list')
     command = [sys.executable, str(script)]
     if cross_platform:
         command.append('--cross-platform')
-    command.append(ref)
+    if ref is not None:
+        command.append(ref)
     result = subprocess.run(
         command,
         check=True,
@@ -97,27 +98,49 @@ def suite_aware_unified_diff(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Show UI test list changes.')
-    parser.add_argument('base_ref', help='Base git ref to compare')
-    parser.add_argument('head_ref', help='Head git ref to compare')
+    parser.add_argument(
+        'base_or_head_ref',
+        metavar='revision',
+        help=(
+            'Git ref to compare; with one ref, compare the working copy test files against that revision'
+        ),
+    )
+    parser.add_argument(
+        'head_ref',
+        nargs='?',
+        metavar='revision',
+        help='Optional head git ref; when provided, the first revision is the base',
+    )
     parser.add_argument(
         '--cross-platform',
         action='store_true',
         help='Forward --cross-platform to ui-test-list for normalized suite headings',
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.head_ref is None:
+        args.base_ref = args.base_or_head_ref
+        args.head_ref = None
+    else:
+        args.base_ref = args.base_or_head_ref
+    del args.base_or_head_ref
+    return args
 
 
 def main() -> int:
     args = parse_args()
-    base_lines = ui_test_list(args.base_ref, cross_platform=args.cross_platform)
-    head_lines = ui_test_list(args.head_ref, cross_platform=args.cross_platform)
+    base_ref = args.base_ref
+    head_ref = args.head_ref
+    head_name = 'working copy' if head_ref is None else head_ref
+
+    base_lines = ui_test_list(base_ref, cross_platform=args.cross_platform)
+    head_lines = ui_test_list(head_ref, cross_platform=args.cross_platform)
 
     diff = ''.join(
         suite_aware_unified_diff(
             base_lines,
             head_lines,
-            fromfile=f'{args.base_ref} test-list',
-            tofile=f'{args.head_ref} test-list',
+            fromfile=f'{base_ref} test-list',
+            tofile=f'{head_name} test-list',
             n=1,
         )
     )

--- a/scripts/ui-test-list-diff
+++ b/scripts/ui-test-list-diff
@@ -1,19 +1,64 @@
 #!/usr/bin/env python3
 
 import argparse
+from dataclasses import dataclass
 import difflib
 import subprocess
 import sys
 from pathlib import Path
 
 
-def ui_test_list(ref: str | None, *, cross_platform: bool = False) -> list[str]:
-    script = Path(__file__).with_name('ui-test-list')
+@dataclass(frozen=True)
+class TestListSource:
+    folder: Path
+    revision: str | None
+    label: str
+
+
+def current_working_copy() -> Path:
+    result = subprocess.run(
+        ['git', 'rev-parse', '--show-toplevel'],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding='utf-8',
+        errors='surrogateescape',
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip()).resolve()
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_folder(folder: str) -> Path:
+    return Path(folder).expanduser().resolve()
+
+
+def parse_test_list_source(value: str, default_folder: Path) -> TestListSource:
+    if '@' in value:
+        folder_text, revision = value.split('@', 1)
+        folder = default_folder if not folder_text else resolve_folder(folder_text)
+        folder_label = 'working copy' if not folder_text else folder_text
+        if revision:
+            return TestListSource(folder, revision, f'{folder_label}@{revision}')
+        return TestListSource(folder, None, folder_label)
+
+    if Path(value).expanduser().is_dir():
+        return TestListSource(resolve_folder(value), None, value)
+
+    return TestListSource(default_folder, value, value)
+
+
+def working_copy_source(default_folder: Path) -> TestListSource:
+    return TestListSource(default_folder, None, 'working copy')
+
+
+def ui_test_list(source: TestListSource, *, cross_platform: bool = False) -> list[str]:
+    script = source.folder / 'scripts' / 'ui-test-list'
     command = [sys.executable, str(script)]
     if cross_platform:
         command.append('--cross-platform')
-    if ref is not None:
-        command.append(ref)
+    if source.revision is not None:
+        command.append(source.revision)
     result = subprocess.run(
         command,
         check=True,
@@ -21,6 +66,7 @@ def ui_test_list(ref: str | None, *, cross_platform: bool = False) -> list[str]:
         text=True,
         encoding='utf-8',
         errors='surrogateescape',
+        cwd=source.folder,
     )
     return result.stdout.splitlines(keepends=True)
 
@@ -98,18 +144,20 @@ def suite_aware_unified_diff(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Show UI test list changes.')
-    parser.add_argument(
-        'base_or_head_ref',
-        metavar='revision',
-        help=(
-            'Git ref to compare; with one ref, compare the working copy test files against that revision'
-        ),
+    source_help = (
+        'UI test-list source as <folder>@<revision>, <folder>, or <revision>; '
+        'folders run their scripts/ui-test-list and omitted revisions use working copy test files'
     )
     parser.add_argument(
-        'head_ref',
+        'base_or_head_source',
+        metavar='source',
+        help=f'{source_help}. With one source, compare the current working copy against that source.',
+    )
+    parser.add_argument(
+        'head_source',
         nargs='?',
-        metavar='revision',
-        help='Optional head git ref; when provided, the first revision is the base',
+        metavar='source',
+        help=f'Optional head {source_help}. When provided, the first source is the base.',
     )
     parser.add_argument(
         '--cross-platform',
@@ -117,30 +165,31 @@ def parse_args() -> argparse.Namespace:
         help='Forward --cross-platform to ui-test-list for normalized suite headings',
     )
     args = parser.parse_args()
-    if args.head_ref is None:
-        args.base_ref = args.base_or_head_ref
-        args.head_ref = None
+    default_folder = current_working_copy()
+    if args.head_source is None:
+        args.base_source = parse_test_list_source(args.base_or_head_source, default_folder)
+        args.head_source = working_copy_source(default_folder)
     else:
-        args.base_ref = args.base_or_head_ref
-    del args.base_or_head_ref
+        args.base_source = parse_test_list_source(args.base_or_head_source, default_folder)
+        args.head_source = parse_test_list_source(args.head_source, default_folder)
+    del args.base_or_head_source
     return args
 
 
 def main() -> int:
     args = parse_args()
-    base_ref = args.base_ref
-    head_ref = args.head_ref
-    head_name = 'working copy' if head_ref is None else head_ref
+    base_source = args.base_source
+    head_source = args.head_source
 
-    base_lines = ui_test_list(base_ref, cross_platform=args.cross_platform)
-    head_lines = ui_test_list(head_ref, cross_platform=args.cross_platform)
+    base_lines = ui_test_list(base_source, cross_platform=args.cross_platform)
+    head_lines = ui_test_list(head_source, cross_platform=args.cross_platform)
 
     diff = ''.join(
         suite_aware_unified_diff(
             base_lines,
             head_lines,
-            fromfile=f'{base_ref} test-list',
-            tofile=f'{head_name} test-list',
+            fromfile=f'{base_source.label} test-list',
+            tofile=f'{head_source.label} test-list',
             n=1,
         )
     )


### PR DESCRIPTION
### Motivation
- Provide a stable, platform-agnostic UI test list output by omitting per-file suffixes so suite headings are consistent across platform-specific spec filenames.

### Description
- Add `argparse` and a `--cross-platform` flag to `scripts/ui-test-list` to control output formatting. 
- Thread a `cross_platform` boolean through `suite_test_list` and `parse_suite_tests` so the parser can omit filenames when the flag is enabled. 
- When `--cross-platform` is set the suite heading is rendered as `Suite Name:` instead of `Suite Name [filename]:`. 
- Replace the previous simple `main()` with `parse_args()` and a new `main()` that passes the parsed `ref` and `--cross-platform` option to `suite_test_list`.

### Testing
- Ran `scripts/ui-test-list --cross-platform` and it produced suite headings without filenames, which succeeded. 
- Ran `scripts/ui-test-list HEAD --cross-platform` and it produced expected cross-platform output, which succeeded. 
- Ran `scripts/ui-test-list` to verify default behavior still includes filenames, which succeeded. 
- Ran `npm run check` to validate repository checks and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f79ced14c8321b8814c059a5f6d41)